### PR TITLE
Add minimal Express server and client scaffold

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# .env.example — FFF Online
+# Porta local (Azure ignora e usa a própria)
+PORT=8080
+
+# CORS do Socket.IO/Express
+# Use "*" em desenvolvimento; em produção, informe seu domínio
+# Ex.: https://fff-online-app.azurewebsites.net
+CORS_ORIGIN=*

--- a/azure-webapp.yml
+++ b/azure-webapp.yml
@@ -1,0 +1,27 @@
+name: Build and deploy Node.js app to Azure Web App
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Deploy to Azure Web App
+        uses: azure/webapps-deploy@v2
+        with:
+          app-name: ${{ secrets.AZURE_WEBAPP_NAME }}
+          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
+          package: .

--- a/fffon-net-client.js
+++ b/fffon-net-client.js
@@ -1,0 +1,4 @@
+// fffon-net-client.js
+(function(){
+  console.log('FFFON client loaded');
+})();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <title>FFF Online</title>
+</head>
+<body>
+  <h1>FFF Online</h1>
+  <p>Servidor ativo.</p>
+  <script src="./fffon-net-client.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "fff-online",
+  "version": "1.0.0",
+  "description": "Farm Fight Formula – sample Node server",
+  "main": "server.js",
+  "license": "MIT",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "nodemon server.js",
+    "test": "node -e \"console.log('no tests')\"",
+    "postinstall": "echo \"FFF Online: no build step\""
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "dotenv": "^16.3.1"
+  },
+  "devDependencies": {
+    "nodemon": "^3.1.0"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,23 @@
+'use strict';
+
+// Minimal Express server for FFF Online
+require('dotenv').config();
+const express = require('express');
+
+const PORT = process.env.PORT || 8080;
+const ORIGIN = process.env.CORS_ORIGIN || '*';
+
+const app = express();
+app.disable('x-powered-by');
+
+// basic CORS header
+app.use((_, res, next) => { res.setHeader('Access-Control-Allow-Origin', ORIGIN); next(); });
+
+// serve static files from project root (index.html, client script, etc.)
+app.use(express.static('.'));
+
+app.get('/health', (_, res) => res.json({ ok: true }));
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- replace complex Socket.IO server with lightweight Express app serving static files
- simplify package manifest and provide stub network client and HTML landing page
- document sample environment variables for local development

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/dotenv)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a3d4fb4088832b8a91f255f9c3d8e3