### PR TITLE
fix: correct net client script path

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
   <script src="/socket.io/socket.io.js"></script>
 
   <!-- Cliente de rede (este arquivo é o que você já tem na lousa ‘Fffonline-net-client’) -->
-  <script src="./net-client.js"></script>
+  <script src="./fffon-net-client.js"></script>
 
   <!-- Seu jogo (versão solo+online). Mantenha o nome que você usa hoje, por exemplo app.js / index.js -->
   <!-- Substitua o caminho abaixo pelo arquivo principal do seu jogo. -->


### PR DESCRIPTION
## Summary
- fix script path to `fffon-net-client.js`

## Testing
- `npm test` (fails: Missing script "test")
- `curl -I http://localhost:8000/fffon-net-client.js`


------
https://chatgpt.com/codex/tasks/task_b_68a3e7c4f29c832ba996c73f5da805aa