### PR TITLE
Add hover and tilt effect assets

### DIFF
--- a/public/fff-effects.css
+++ b/public/fff-effects.css
@@ -1,0 +1,103 @@
+/* ===== FFF: efeitos visuais & hover ===== */
+
+/* transições básicas */
+.hand .card,
+#playerBoard .card,
+#aiBoard .card,
+.start .deckpick .btn {
+  transition: transform .20s ease, box-shadow .20s ease, filter .20s ease, opacity .20s ease;
+  will-change: transform, box-shadow, filter;
+}
+
+/* destaque/elevação (mão e board do jogador) */
+.hand .card:hover,
+#playerBoard .card:hover {
+  transform: translateY(-6px) scale(1.03);
+  box-shadow: 0 16px 30px rgba(0,0,0,.45),
+              0 0 0 2px rgba(124,196,255,.15) inset;
+  filter: saturate(1.05);
+}
+
+/* efeito mais sutil no tabuleiro do inimigo (apenas visual) */
+#aiBoard .card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 10px 20px rgba(0,0,0,.3),
+              0 0 0 1px rgba(255,255,255,.06) inset;
+}
+
+/* botões de deck na tela inicial */
+.start .deckpick .btn {
+  transform-style: preserve-3d;
+}
+.start .deckpick .btn:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 12px 24px rgba(0,0,0,.35),
+              0 0 0 2px rgba(124,196,255,.18) inset;
+  filter: saturate(1.05);
+}
+
+/* brilho que segue o mouse (usa --px/--py definidos via JS) */
+.card { --px:50%; --py:50%; position: relative; }
+.card::after {
+  content:"";
+  position:absolute; inset:-1px; border-radius:inherit;
+  background: radial-gradient(220px 220px at var(--px) var(--py),
+              rgba(255,255,255,.25), rgba(255,255,255,0) 40%);
+  opacity: 0; pointer-events:none; transition: opacity .18s ease;
+}
+.card:hover::after { opacity:.35; }
+
+/* arte também mexe levemente */
+.card .art { transition: transform .18s ease; }
+
+/* custo em vermelho quando não há mana suficiente (seu código já marca .blocked) */
+.card.blocked .cost-badge {
+  background: radial-gradient(circle at 30% 30%, #ffc2c2, #ff4d6d) !important;
+  color: #24040a !important;
+  box-shadow: 0 8px 14px rgba(255,77,109,.35),
+              inset 0 0 18px rgba(255,255,255,.25);
+  filter: saturate(1.05);
+}
+
+/* botão "atacar diretamente" com feedback */
+.face-attack-btn {
+  transform: translateZ(0);
+  transition: transform .15s ease, box-shadow .15s ease;
+}
+.face-attack-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 22px rgba(0,0,0,.35);
+}
+
+/* tooltips (habilidades) mais legíveis caso você use data-tooltip */
+[data-tip] {
+  position: relative;
+}
+[data-tip]:hover::after {
+  content: attr(data-tip);
+  position: absolute;
+  z-index: 40;
+  left: 0;
+  bottom: calc(100% + 8px);
+  white-space: normal;
+  max-width: 240px;
+  background: #121a44;
+  color: #e6e9ff;
+  border: 1px solid #2b3a86;
+  border-radius: 10px;
+  padding: 10px 12px;
+  box-shadow: 0 18px 40px rgba(0,0,0,.45);
+  line-height: 1.35;
+  font-size: 13px;
+}
+
+/* transições rápidas de seleção/foco */
+.selectable {
+  outline: 2px solid rgba(124,196,255,.8);
+  box-shadow: 0 0 0 6px rgba(124,196,255,.2);
+}
+
+/* melhora a sensação de click */
+.card:active { transform: translateY(-2px) scale(1.015); }
+.start .deckpick .btn:active { transform: translateY(-1px); }
+

--- a/public/fff-effects.js
+++ b/public/fff-effects.js
@@ -1,0 +1,49 @@
+// ===== FFF efeitos/hover/tilt (sem dependências) =====
+(function () {
+  const TILT_ATTR = 'data-tilt-wired';
+
+  function wireCard(card){
+    if (!card || card.getAttribute(TILT_ATTR)) return;
+    const art = card.querySelector('.art');
+
+    card.addEventListener('mousemove', (e)=>{
+      const r = card.getBoundingClientRect();
+      const px = ((e.clientX - r.left) / r.width) * 100;
+      const py = ((e.clientY - r.top) / r.height) * 100;
+      card.style.setProperty('--px', px + '%');
+      card.style.setProperty('--py', py + '%');
+      if (art){
+        const tx = (px - 50) / 5, ty = (py - 50) / 5;
+        art.style.transform = `translate3d(${tx*3}px, ${ty*3}px, 0) scale(1.06)`;
+      }
+    });
+
+    card.addEventListener('mouseleave', ()=>{
+      if (art) art.style.transform = 'translate3d(0,0,0)';
+    });
+
+    card.setAttribute(TILT_ATTR, '1');
+  }
+
+  function scan(scope=document){
+    scope.querySelectorAll('.card').forEach(wireCard);
+  }
+
+  // observa o DOM por novas cartas renderizadas
+  const mo = new MutationObserver((muts)=>{
+    for (const m of muts){
+      if (m.type === 'childList'){
+        m.addedNodes.forEach((n)=>{
+          if (!(n instanceof HTMLElement)) return;
+          if (n.classList?.contains('card')) wireCard(n);
+          else scan(n);
+        });
+      }
+    }
+  });
+
+  document.addEventListener('DOMContentLoaded', ()=>{
+    scan(document);
+    mo.observe(document.body, { childList:true, subtree:true });
+  });
+})();

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Farm Fight Formula — Online</title>
+  <title>FFF Farm Fight Formula — Online</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
   <style>
@@ -64,6 +64,7 @@
 
     @media (max-width:720px){.board{grid-template-columns:repeat(auto-fit,minmax(150px,1fr))}.card{width:150px}.name{font-size:13px}}
   </style>
+  <link rel="stylesheet" href="fff-effects.css">
   <!-- Online: Socket.IO + cliente -->
   <script src="/socket.io/socket.io.js"></script>
   <script src="/ffon-net-client.js"></script>
@@ -240,5 +241,6 @@
   window.addEventListener('pointerdown',()=>{initAudio();ensureRunning()},{once:true});
 })();
 </script>
+  <script defer src="fff-effects.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Link new hover and tilt effect stylesheet and script in the HTML page
- Add CSS for 3D hover, shine, and tooltip effects
- Provide JavaScript to wire tilt and shine behavior on cards

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a3fc8f3428832b902c79b864f70921