### PR TITLE
Serve static client from public directory

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html lang="pt-BR"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/><title>FFF Farm Fight Formula</title><link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link rel="stylesheet" href="public/css/style.css"></head><body><div class="start" id="start"><div class="panel"><div class="brand">
+<!DOCTYPE html><html lang="pt-BR"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/><title>FFF Farm Fight Formula</title><link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link rel="stylesheet" href="css/style.css"></head><body><div class="start" id="start"><div class="panel"><div class="brand">
   <svg class="logo-wordmark" viewBox="0 0 520 64" xmlns="http://www.w3.org/2000/svg" aria-label="Farm Fight Formula logo">
     <defs>
       <linearGradient id="mono" x1="0" y1="0" x2="1" y2="1">
@@ -34,8 +34,8 @@
 
 <div class="zone-title">Sua Mão</div><div class="hand" id="playerHand"></div><div class="zone-title">Registro</div><div class="log" id="log"></div><div class="footer"><div class="face">👤 Você <span class="gem hp" id="playerHP2">30</span></div><div class="face">🧿 Inimigo <span class="gem hp" id="aiHP2">30</span></div></div></div><div class="end-overlay" id="endOverlay"><div class="end-box"><div class="end-msg" id="endMsg"></div><div class="end-sub" id="endSub"></div><div class="end-actions"><button class="btn" id="playAgainBtn">Jogar de novo</button><button class="btn" id="rematchBtn">Revanche</button><button class="btn-ghost" id="menuBtn">Menu inicial</button></div></div></div>
 <script src="/socket.io/socket.io.js"></script>
-<script src="public/js/net-client.js"></script>
-<script src="public/js/multiplayer.js"></script>
-<script src="public/js/game.js"></script>
+<script src="js/net-client.js"></script>
+<script src="js/multiplayer.js"></script>
+<script src="js/game.js"></script>
 </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -10,11 +10,7 @@ const io = new Server(server);
 
 const PORT = process.env.PORT || 3000;
 
-app.use('/public', express.static(path.join(__dirname, 'public')));
-
-app.get('/', (req, res) => {
-  res.sendFile(path.join(__dirname, 'index.html'));
-});
+app.use(express.static(path.join(__dirname, 'public')));
 
 io.on('connection', (socket) => {
   socket.on('host', () => {


### PR DESCRIPTION
## Summary
- Move client `index.html` into `public/` and update asset paths to relative references.
- Serve `public` directory directly with Express, dropping manual route handler.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a4cb2a2d40832bb65723b42a8ab4a8