### PR TITLE
Validate deck choice before broadcasting

### DIFF
--- a/server.js
+++ b/server.js
@@ -10,6 +10,9 @@ const io = new Server(server);
 
 const PORT = process.env.PORT || 3000;
 
+// Decks permitidos no modo multiplayer
+const VALID_DECKS = new Set(['vikings', 'animais', 'pescadores', 'floresta', 'custom']);
+
 app.use(express.static(path.join(__dirname, 'public')));
 
 io.on('connection', (socket) => {
@@ -37,10 +40,15 @@ io.on('connection', (socket) => {
 
   socket.on('deckChoice', (deckId) => {
     const room = socket.data.room;
-    if (room) {
-      socket.data.deckChosen = deckId;
-      socket.to(room).emit('opponentDeckConfirmed', deckId);
+    if (!room) return;
+
+    if (!VALID_DECKS.has(deckId)) {
+      socket.emit('deckError', 'Deck inválido');
+      return;
     }
+
+    socket.data.deckChosen = deckId;
+    socket.to(room).emit('opponentDeckConfirmed', deckId);
   });
 
   socket.on('startReady', () => {


### PR DESCRIPTION
## Summary
- Only accept multiplayer deck choices that match a predefined list
- Notify client with `deckError` if an invalid deck is chosen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a4cc4683d8832ba3207304f275b548