### PR TITLE
limpa dados do socket ao desconectar

### DIFF
--- a/server.js
+++ b/server.js
@@ -85,10 +85,18 @@ io.on('connection', (socket) => {
   });
 
   socket.on('disconnecting', () => {
-    const room = socket.data.room;
+    const { room } = socket.data;
     if (room) {
       socket.to(room).emit('opponentLeft');
     }
+
+    delete socket.data.room;
+    delete socket.data.deckChosen;
+    delete socket.data.startReady;
+  });
+
+  socket.on('disconnect', async () => {
+    // Additional asynchronous operations can be performed here
   });
 });
 


### PR DESCRIPTION
## Summary
- remove `room`, `deckChosen` e `startReady` de `socket.data` ao desconectar
- adiciona callback para `disconnect` para futuras operações assíncronas

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a4cd29f0d4832bbd22388ba6e33435