### PR TITLE
feat: track rooms and expose list

### DIFF
--- a/public/js/net-client.js
+++ b/public/js/net-client.js
@@ -26,6 +26,10 @@
       connectIfNeeded();
       socket.emit('join', code);
     },
+    listRooms() {
+      connectIfNeeded();
+      socket.emit('listRooms');
+    },
     isHost() {
       return role === 'host';
     },
@@ -64,6 +68,9 @@
     },
     onJoinError(handler) {
       socket.on('joinError', handler);
+    },
+    onRooms(handler) {
+      socket.on('rooms', handler);
     },
     onOpponentLeft(handler) {
       socket.on('opponentLeft', handler);

--- a/server.js
+++ b/server.js
@@ -13,6 +13,9 @@ const PORT = process.env.PORT || 3000;
 // Decks permitidos no modo multiplayer
 const VALID_DECKS = new Set(['vikings', 'animais', 'pescadores', 'floresta', 'custom']);
 
+// Informações sobre salas em memória
+const rooms = new Map();
+
 app.use(express.static(path.join(__dirname, 'public')));
 
 io.on('connection', (socket) => {
@@ -20,22 +23,40 @@ io.on('connection', (socket) => {
     let room;
     do {
       room = randomUUID().slice(0, 6);
-    } while (io.sockets.adapter.rooms.has(room));
+    } while (rooms.has(room));
     socket.join(room);
     socket.data.room = room;
+    rooms.set(room, { host: socket.id, players: 1 });
     socket.emit('hosted', room);
   });
 
   socket.on('join', (room) => {
-    const clients = io.sockets.adapter.rooms.get(room);
-    if (clients && clients.size === 1) {
-      socket.join(room);
-      socket.data.room = room;
-      socket.emit('joined', room);
-      socket.to(room).emit('guestJoined');
-    } else {
+    const info = rooms.get(room);
+    if (!info) {
       socket.emit('joinError', 'Sala inexistente ou cheia');
+      return;
     }
+    if (info.host === socket.id) {
+      socket.emit('joinError', 'Você já é o host desta sala');
+      return;
+    }
+    if (info.players >= 2) {
+      socket.emit('joinError', 'Sala inexistente ou cheia');
+      return;
+    }
+    socket.join(room);
+    socket.data.room = room;
+    info.players++;
+    socket.emit('joined', room);
+    socket.to(room).emit('guestJoined');
+  });
+
+  socket.on('listRooms', () => {
+    const open = [...rooms.entries()].map(([code, info]) => ({
+      code,
+      players: info.players,
+    }));
+    socket.emit('rooms', open);
   });
 
   socket.on('deckChoice', (deckId) => {
@@ -88,6 +109,13 @@ io.on('connection', (socket) => {
     const { room } = socket.data;
     if (room) {
       socket.to(room).emit('opponentLeft');
+      const info = rooms.get(room);
+      if (info) {
+        info.players--;
+        if (info.host === socket.id || info.players <= 0) {
+          rooms.delete(room);
+        }
+      }
     }
 
     delete socket.data.room;


### PR DESCRIPTION
## Summary
- track multiplayer rooms server-side
- prevent host from rejoining own room and expose listRooms socket event
- add client helpers for listing rooms

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a51856cf1c832b969719fac29048c9