### PR TITLE
Centralize logo and randomize backgrounds

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -18,7 +18,7 @@
 html,body{height:100%;overflow:auto}
 body{margin:0;
 font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Helvetica,Arial;
-background:radial-gradient(1200px 700px at 20% 0%,#0e1340 0%,var(--bg) 60%);
+background:var(--body-bg,none),radial-gradient(1200px 700px at 20% 0%,#0e1340 0%,var(--bg) 60%);
 color:var(--text)}
 h1{margin:0 0 12px;
 font-size:clamp(22px,4vw,36px);
@@ -324,9 +324,11 @@ width:min(96vw,1200px)}
 .emoji-popup.opponent{top:60px;right:20px}
 .emoji-popup.show{opacity:1}
 .brand{display:flex;
+flex-direction:column;
 align-items:center;
 justify-content:center;
-gap:10px}
+gap:10px;
+text-align:center}
 .logoFFF{width:36px;
 height:36px}
 .deckpick{display:grid;

--- a/public/index.html
+++ b/public/index.html
@@ -13,7 +13,7 @@
   <div class="start" id="titleMenu">
     <div class="panel">
       <div class="brand">
-        <img src="img/ui/logos/logo2.webp" class="logo-wordmark holo-logo" alt="Farm Fight Formula logo">
+        <img src="img/ui/logos/logo2.png" class="logo-wordmark holo-logo" alt="Farm Fight Formula logo">
       </div>
       <div class="main-actions">
         <button class="btn" id="menuSolo">Jogar Solo</button>
@@ -27,7 +27,7 @@
   <div class="start" id="start" style="display:none">
     <div class="panel">
       <div class="brand">
-        <img src="img/ui/logos/logo2.webp" class="logo-wordmark holo-logo" alt="Farm Fight Formula logo">
+        <img src="img/ui/logos/logo2.png" class="logo-wordmark holo-logo" alt="Farm Fight Formula logo">
       </div>
       <p class="sub">Escolha um deck e parta para a arena.</p>
       <div class="deckpick">

--- a/public/js/menu.js
+++ b/public/js/menu.js
@@ -1,7 +1,15 @@
-document.addEventListener('DOMContentLoaded', () => {
-  const backgrounds=['img/ui/backgrounds/fff-bg-01.webp','img/ui/backgrounds/fff-bg-02.webp'];
-  const pick=backgrounds[Math.floor(Math.random()*backgrounds.length)];
-  document.documentElement.style.setProperty('--start-bg',`url('${pick}') center/cover no-repeat`);
+document.addEventListener('DOMContentLoaded', async () => {
+  try{
+    const res=await fetch('/backgrounds');
+    const list=await res.json();
+    if(list.length){
+      const pick=list[Math.floor(Math.random()*list.length)];
+      const url=`img/ui/backgrounds/${pick}`;
+      const style=`url('${url}') center/cover no-repeat`;
+      document.documentElement.style.setProperty('--start-bg',style);
+      document.body.style.setProperty('--body-bg',style);
+    }
+  }catch(err){console.error('Failed to load backgrounds',err);}
   const titleMenu = document.getElementById('titleMenu');
   const deckScreen = document.getElementById('start');
   const multiMenu = document.getElementById('multiplayerMenu');

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const http = require('http');
 const path = require('path');
 const { Server } = require('socket.io');
 const { randomUUID } = require('crypto');
+const fs = require('fs');
 
 const app = express();
 const server = http.createServer(app);
@@ -17,6 +18,15 @@ const VALID_DECKS = new Set(['vikings', 'animais', 'pescadores', 'floresta', 'cu
 const rooms = new Map();
 
 app.use(express.static(path.join(__dirname, 'public')));
+
+app.get('/backgrounds', (req, res) => {
+  const dir = path.join(__dirname, 'public', 'img', 'ui', 'backgrounds');
+  fs.readdir(dir, (err, files) => {
+    if (err) return res.status(500).json([]);
+    const list = files.filter(f => /\.(png|jpe?g|webp|gif)$/i.test(f));
+    res.json(list);
+  });
+});
 
 io.on('connection', (socket) => {
   socket.on('host', () => {


### PR DESCRIPTION
## Summary
- Center landing page logo and switch to `logo2.png`
- Serve available background images and pick one at runtime for body and start screen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a8ef1d87bc832b820224962a980bcf