### PR TITLE
refactor: update card UI and deck assets

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -24,7 +24,8 @@ background-image:var(--body-bg),radial-gradient(1200px 700px at 20% 0%,#0e1340 0
 background-size:cover,auto;
 background-repeat:no-repeat,no-repeat;
 background-position:center,0 0;
-color:var(--text)}
+color:var(--text);
+padding-bottom:48px}
 h1{margin:0 0 12px;
 font-size:clamp(22px,4vw,36px);
 letter-spacing:.5px}
@@ -132,8 +133,7 @@ width:calc(5*176px + 4*14px + 24px)}
  --rY:0deg}
 .card .head-bar{background:linear-gradient(180deg,rgba(0,0,0,.6),rgba(0,0,0,.2));padding:2px 4px;border-radius:6px;display:flex;flex-direction:column;gap:2px}
 .card .head-bar .name{font-weight:800;font-size:14px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;background:linear-gradient(180deg,rgba(0,0,0,.7),rgba(0,0,0,.3));padding:0 4px;border-radius:4px}
-.card .head-bar .cost-bar{display:flex;justify-content:flex-end;align-items:center;gap:4px;position:relative}
-.card .head-bar .cost-bar .badge{position:absolute;left:4px}
+.card .head-bar .cost-bar{display:flex;justify-content:flex-start;align-items:center;gap:4px;position:relative}
 .card .mana-row{display:flex;align-items:center;gap:4px}
 /* Mana icons use a local sprite sheet with five gems in a row */
 .mana-dot{width:16px;height:16px;background-image:url('../img/mana/mana.png');background-size:500% 100%;image-rendering:pixelated;display:inline-block}
@@ -149,6 +149,12 @@ border-radius:999px;
 border:1px solid rgba(255,255,255,.14)}
 .badge.atk{background:linear-gradient(180deg,#1f2a64,#15204a)}
 .badge.def{background:linear-gradient(180deg,#2a5f3a,#1e462b)}
+ .stance-label{position:relative;padding:3px 12px;border-radius:999px;border:1px solid rgba(255,255,255,.14);font-size:10px;font-weight:700;overflow:hidden;color:#fff}
+ .stance-label.attack{background:linear-gradient(180deg,#1f2a64,#15204a)}
+ .stance-label.defense{background:linear-gradient(180deg,#2a5f3a,#1e462b)}
+ .stance-label::before{content:"";position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:16px;opacity:.3}
+ .stance-label.attack::before{content:"⚔️"}
+ .stance-label.defense::before{content:"🛡️"}
 /* tribe text removed */
 .art{display:flex;
 align-items:center;
@@ -160,12 +166,8 @@ position:relative}
 .art::after{content:"";position:absolute;inset:0;background:linear-gradient(115deg,rgba(255,255,255,.25),rgba(255,255,255,0) 60%);mix-blend-mode:screen;pointer-events:none;opacity:.2}
 .text{font-size:12px;color:#d9e3ff;background:#0e1435;border:1px solid #25306a;border-radius:10px;padding:4px;margin:0;max-width:100%;word-break:break-word;box-sizing:border-box;white-space:normal;overflow:hidden;height:auto}
 .text::after{content:"";display:block;clear:both}
-.stats{display:flex;
-justify-content:space-between;
-align-items:center;
-margin:0;
-min-height:26px;
-align-self:end}
+.stats{display:flex;justify-content:space-between;align-items:center;margin:0;min-height:26px;align-self:end;gap:4px}
+.stats .stance-label{flex:1;margin:0 4px;text-align:center}
 
 .gem{padding:6px 10px;
 border-radius:999px;

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -44,6 +44,7 @@ function preloadAssets(){
   const list=[];
   for(const [key,info] of Object.entries(DECK_ASSETS)){
     list.push(`/img/decks/${info.folder}/card-backs/${info.back}-cb-default.webp`);
+    list.push(`/img/decks/${info.folder}/deck-backs/${info.back}-db-default.webp`);
     (DECK_IMAGES[key]||[]).forEach(fn=>{
       const base=`/img/decks/${info.folder}/characters/${fn.replace(/\.[^.]+$/,'')}.png`;
       list.push(base);
@@ -69,7 +70,7 @@ function setCardBacks(){
   const apply=(deck,drawId,discId)=>{
     const info=DECK_ASSETS[deck];
     if(!info)return;
-    const base=`/img/decks/${info.folder}/card-backs/${info.back}-cb-default.webp`;
+    const base=`/img/decks/${info.folder}/deck-backs/${info.back}-db-default.webp`;
     const drawImg=document.querySelector(`#${drawId} img`);
     const discImg=document.querySelector(`#${discId} img`);
     drawImg&&setSrcFallback(drawImg,[base]);
@@ -79,7 +80,22 @@ function setCardBacks(){
   apply(G.aiDeckChoice,'aiDrawPile','aiDiscardPile');
 }
 
-function determineClass(c){const n=c.name.toLowerCase();if(n.includes('guardião'))return{name:'Guardião',group:'tank'};if(n.includes('berserker'))return{name:'Berserker',group:'tank'};if(n.includes('caçador'))return{name:'Caçador',group:'dps'};if(n.includes('curandeir'))return{name:'Curandeiro',group:'support'};if(n.includes('sacerdote'))return{name:'Tecelão',group:'support'};if(n.includes('xamã'))return{name:'Xamã',group:'control'};if(n.includes('serpente'))return{name:'Serpente',group:'dps'};return null;}
+function determineClass(c){
+  const n=c.name.toLowerCase();
+  if(n.includes('berserker')) return {name:'Berserker',group:'tank'};
+  if(n.includes('guardião do véu')||n.includes('véu')) return {name:'Guardião do Véu',group:'control'};
+  if(n.includes('guardião')) return {name:'Guardião',group:'tank'};
+  if(n.includes('uivante')) return {name:'Uivante',group:'tank'};
+  if(n.includes('caçador')) return {name:'Caçador',group:'dps'};
+  if(n.includes('runomante')) return {name:'Runomante',group:'dps'};
+  if(n.includes('serpente')) return {name:'Serpente',group:'dps'};
+  if(n.includes('curandeir')) return {name:'Curandeiro',group:'support'};
+  if(n.includes('totêmico')||n.includes('totemico')) return {name:'Totêmico',group:'support'};
+  if(n.includes('sacerdote')||n.includes('tecelão')) return {name:'Tecelão',group:'support'};
+  if(n.includes('xamã')) return {name:'Xamã',group:'control'};
+  if(n.includes('corvo')) return {name:'Corvo',group:'control'};
+  return null;
+}
 // deck builder DOM (may be null if builder UI not present)
 const poolEl=$('#pool'), chosenEl=$('#chosen'), countEl=$('#countDeck'), curveEl=$('#curve');
 // safe builder functions (no-ops if UI not present)
@@ -129,13 +145,13 @@ function cardNode(c,owner,onBoard=false){
     if(n)kwTags.push(`<span class='keyword' data-tip='${tip}' title='${tip}'>${n}</span>`);
   }
   const cls=determineClass(c);if(cls)kwTags.push(`<span class='class-tag ${cls.group}'>${cls.name}</span>`);
-  let text=c.text||'';
-  if(kwTags.some(s=>s.includes('>'+text.trim()+'<'))) text='';
+  const text=c.text||'';
+  const tip=text&&!kwTags.some(s=>s.includes('>'+text.trim()+'<'))?text:'';
   d.innerHTML=`<div class="bg bg-${c.deck||'default'}"></div>
-  <div class="head-bar"><div class="name">${c.name}</div><div class="cost-bar">${c.stance?`<span class=\"badge ${c.stance==='defense'?'def':'atk'}\">${c.stance==='defense'?'DEFESA':'ATAQUE'}</span>`:''}<div class="mana-row">${manaDots}<span class="mana-num">${c.cost}</span></div></div></div>
+  <div class="head-bar"><div class="name">${c.name}</div><div class="cost-bar"><div class="mana-row">${manaDots}<span class="mana-num">${c.cost}</span></div></div></div>
   <div class="art"></div>
-  <div class="text">${kwTags.join(' ')}${text?(' '+text):''}</div>
-  <div class="stats"><span class="gem atk">⚔️ ${c.atk}</span><span class="gem hp ${c.hp<=2?'low':''}">❤️ ${c.hp}</span></div>`;
+  <div class="text" ${tip?`data-tip='${tip}' title='${tip}'`:''}>${kwTags.join(' ')}</div>
+  <div class="stats"><span class="gem atk">⚔️ ${c.atk}</span>${c.stance?`<span class=\"stance-label ${c.stance}\">${c.stance==='defense'?'DEFESA':'ATAQUE'}</span>`:''}<span class="gem hp ${c.hp<=2?'low':''}">❤️ ${c.hp}</span></div>`;
   if(!onBoard){
     const art=d.querySelector('.art');
     createProjection(art,c);


### PR DESCRIPTION
## Summary
- show deck piles using deck-back images
- add RPG role classes and rework card stance badge
- polish card cost/stance layout and body spacing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a94e96f70c832b830c6d185e7a0308