### PR TITLE
Add resign option to multiplayer matches

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -14,8 +14,8 @@
 --cb-pescadores:url('/img/decks/fJord-fishers/card-backs/jf-cb-default.webp');
 --cb-floresta:url('/img/decks/forest-beasts/card-backs/fb-cb-default.webp');
 --cb-animais:url('/img/decks/north-beasts/card-backs/nb-cb-default.webp');
---body-bg:none;
---start-bg:none}
+--body-bg:url('/img/ui/backgrounds/fff-bg-01.webp');
+--start-bg:url('/img/ui/backgrounds/fff-bg-01.webp')}
 *{box-sizing:border-box}
 html,body{height:100%;overflow:auto}
 body{margin:0;
@@ -142,7 +142,7 @@ width:calc(5*176px + 4*14px + 24px)}
 .mana-dot.pescadores{background-position:50% 0}
 .mana-dot.floresta{background-position:75% 0}
 .mana-dot.custom{background-position:100% 0}
-.mana-num{font-weight:900;margin-left:4px}
+.mana-num{font-weight:900}
 .badge{font-size:10px;
 padding:3px 6px;
 border-radius:999px;
@@ -704,9 +704,11 @@ color:#24040a}
 .card-popup{position:fixed;padding:4px 6px;background:rgba(0,0,0,.8);color:#fff;border-radius:4px;font-size:12px;z-index:2000;pointer-events:none;transform:translate(-50%,-100%)}
 @keyframes holoBounce{0%,100%{transform:translate(-50%,-50%) translateY(0)}50%{transform:translate(-50%,-50%) translateY(-6px)}}
 
+@keyframes logoBounce{0%,100%{transform:translateY(0)}50%{transform:translateY(-6px)}}
+
 .ency-card.bg-custom{background:linear-gradient(180deg,#1a1a3f,#101028)}
 
 .brand .logo-wordmark{width:min(92vw,520px);
 height:auto;
 display:block}
-.holo-logo{animation:holoBounce 2s ease-in-out infinite;filter:drop-shadow(0 0 6px rgba(0,255,255,.6))}
+.holo-logo{animation:logoBounce 2s ease-in-out infinite;filter:drop-shadow(0 0 6px rgba(0,255,255,.6))}

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -44,7 +44,6 @@ function preloadAssets(){
   const list=[];
   for(const [key,info] of Object.entries(DECK_ASSETS)){
     list.push(`/img/decks/${info.folder}/card-backs/${info.back}-cb-default.webp`);
-    list.push(`/img/decks/${info.folder}/deck-backs/${info.back}-db-default.webp`);
     (DECK_IMAGES[key]||[]).forEach(fn=>{
       const base=`/img/decks/${info.folder}/characters/${fn.replace(/\.[^.]+$/,'')}.png`;
       list.push(base);
@@ -70,7 +69,7 @@ function setCardBacks(){
   const apply=(deck,drawId,discId)=>{
     const info=DECK_ASSETS[deck];
     if(!info)return;
-    const base=`/img/decks/${info.folder}/deck-backs/${info.back}-db-default.webp`;
+    const base=`/img/decks/${info.folder}/card-backs/${info.back}-cb-default.webp`;
     const drawImg=document.querySelector(`#${drawId} img`);
     const discImg=document.querySelector(`#${discId} img`);
     drawImg&&setSrcFallback(drawImg,[base]);
@@ -148,7 +147,7 @@ function cardNode(c,owner,onBoard=false){
   const text=c.text||'';
   const tip=text&&!kwTags.some(s=>s.includes('>'+text.trim()+'<'))?text:'';
   d.innerHTML=`<div class="bg bg-${c.deck||'default'}"></div>
-  <div class="head-bar"><div class="name">${c.name}</div><div class="cost-bar"><div class="mana-row">${manaDots}<span class="mana-num">${c.cost}</span></div></div></div>
+  <div class="head-bar"><div class="name">${c.name}</div><div class="cost-bar"><div class="mana-row"><span class="mana-num">${c.cost}</span>${manaDots}</div></div></div>
   <div class="art"></div>
   <div class="text" ${tip?`data-tip='${tip}' title='${tip}'`:''}>${kwTags.join(' ')}</div>
   <div class="stats"><span class="gem atk">⚔️ ${c.atk}</span>${c.stance?`<span class=\"stance-label ${c.stance}\">${c.stance==='defense'?'DEFESA':'ATAQUE'}</span>`:''}<span class="gem hp ${c.hp<=2?'low':''}">❤️ ${c.hp}</span></div>`;
@@ -310,7 +309,7 @@ if(els.openMenuBtn)els.openMenuBtn.addEventListener('click',()=>{els.gameMenu.cl
 if(els.closeMenuBtn)els.closeMenuBtn.addEventListener('click',()=>{els.gameMenu.classList.remove('show')});
 if(els.mainMenuBtn)els.mainMenuBtn.addEventListener('click',()=>{els.gameMenu.classList.remove('show');els.start.style.display='grid';els.wrap.style.display='none';startMenuMusic('menu');if(window.isMultiplayer&&window.NET){NET.disconnect();}window.isMultiplayer=false;window.mpState=null;const custom=document.querySelector('.deckbtn[data-deck="custom"]');custom&&(custom.style.display='');if(els.startGame){els.startGame.textContent='Jogar';els.startGame.disabled=true;}});
 if(els.restartBtn)els.restartBtn.addEventListener('click',()=>{if(!window.isMultiplayer){els.gameMenu.classList.remove('show');startGame()}});
-if(els.resignBtn)els.resignBtn.addEventListener('click',()=>{els.gameMenu.classList.remove('show');if(window.isMultiplayer&&window.NET){NET.disconnect();}endGame(false)});
+if(els.resignBtn)els.resignBtn.addEventListener('click',()=>{els.gameMenu.classList.remove('show');if(window.isMultiplayer&&window.NET){NET.resign();}endGame(false)});
 if(els.emojiBar){els.emojiBar.querySelectorAll('.emoji-btn').forEach(b=>b.addEventListener('click',()=>{const em=b.dataset.emoji;showEmoji('player',em);if(window.isMultiplayer&&window.NET){NET.sendEmoji(em)}}));}
 function initDeckButtons(){
   $$('.deckbtn').forEach(btn=>{
@@ -363,7 +362,7 @@ els.playAgainBtn.addEventListener('click',()=>{if(window.isMultiplayer){showMult
 function handleMove(move){switch(move.type){case 'summon':{summon('ai',move.card,move.stance,true);applyBattlecryEffects('ai',move.effects||[]);G.aiMana-=move.card.cost;renderAll();break}case 'attack':{const a=G.aiBoard.find(x=>x.id===move.attackerId);const t=G.playerBoard.find(x=>x.id===move.targetId);if(a&&t)attackCard(a,t);break}case 'attackFace':{const a=G.aiBoard.find(x=>x.id===move.attackerId);if(a)attackFace(a,'player');break}}}
 function handleTurn(turn){if(turn==='end'){G.current='player';G.chosen=null;updateTargetingUI();newTurn()}}
 if(window.NET){NET.onOpponentDeckConfirmed(d=>{G.aiDeckChoice=d;if(window.mpState==='waitingDeck'){els.startGame.textContent='Iniciar';els.startGame.disabled=false;window.mpState='readyStart'}else{window.opponentConfirmed=true}});NET.onStartGame(()=>{els.start.style.display='none';els.wrap.style.display='block';initAudio();ensureRunning();stopMenuMusic();startGame(NET.isHost()?'player':'ai');window.mpState=null;window.opponentConfirmed=false});NET.onOpponentName(n=>{window.opponentName=n;updateOpponentLabel()})}
-if(window.NET){NET.onMove(handleMove);NET.onTurn(handleTurn);NET.onEmoji(e=>showEmoji('opponent',e));NET.onOpponentLeft(()=>{log('Oponente desconectou.');if(window.isMultiplayer&&els.wrap.style.display==='block')endGame(true);});NET.onRematch(()=>{showMultiplayerDeckSelect();els.endOverlay.classList.remove('show')})}
+if(window.NET){NET.onMove(handleMove);NET.onTurn(handleTurn);NET.onEmoji(e=>showEmoji('opponent',e));NET.onOpponentLeft(()=>{log('Oponente desconectou.');if(window.isMultiplayer&&els.wrap.style.display==='block')endGame(true);});NET.onOpponentResigned(()=>endGame(true));NET.onRematch(()=>{showMultiplayerDeckSelect();els.endOverlay.classList.remove('show')})}
 document.addEventListener('DOMContentLoaded',tryStartMenuMusicImmediate);
 document.addEventListener('visibilitychange',()=>{if(document.visibilityState==='visible')tryStartMenuMusicImmediate()});
 document.addEventListener('pointerdown',()=>{tryStartMenuMusicImmediate()},{once:true});

--- a/public/js/menu.js
+++ b/public/js/menu.js
@@ -1,19 +1,4 @@
-document.addEventListener('DOMContentLoaded', async () => {
-  try{
-    const res=await fetch('/backgrounds');
-    const list=await res.json();
-    if(list.length){
-      const pick=list[Math.floor(Math.random()*list.length)];
-      const url=`/img/ui/backgrounds/${pick}`;
-      const root=document.documentElement;
-      const img=new Image();
-      img.onload=()=>{
-        root.style.setProperty('--start-bg',`url('${url}')`);
-        root.style.setProperty('--body-bg',`url('${url}')`);
-      };
-      img.src=url;
-    }
-  }catch(err){console.error('Failed to load backgrounds',err);}
+document.addEventListener('DOMContentLoaded', () => {
   const titleMenu = document.getElementById('titleMenu');
   const deckScreen = document.getElementById('start');
   const multiMenu = document.getElementById('multiplayerMenu');

--- a/public/js/net-client.js
+++ b/public/js/net-client.js
@@ -60,6 +60,9 @@
     requestRematch() {
       socket.emit('rematch');
     },
+    resign() {
+      socket.emit('resign');
+    },
     onOpponentDeckConfirmed(handler) {
       socket.on('opponentDeckConfirmed', handler);
     },
@@ -98,6 +101,9 @@
     },
     onOpponentReconnected(handler) {
       socket.on('opponentReconnected', handler);
+    },
+    onOpponentResigned(handler) {
+      socket.on('opponentResigned', handler);
     },
     onOpponentName(handler){
       socket.on('opponentName',handler);


### PR DESCRIPTION
## Summary
- Allow players to resign and instantly notify opponents
- Add client hooks and UI to handle resign events
- Center the main logo by using a dedicated bounce animation
- Display mana cost numbers before their icons on cards
- Replace random backgrounds with a fixed backdrop
- Load card back images for deck piles and drop missing deck back fetches

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a95187670c832b853e8e8132875df3