### PR TITLE
Add particle effects asset directory

### DIFF
--- a/public/img/README.md
+++ b/public/img/README.md
@@ -4,7 +4,8 @@ Binary art files are not stored in this repository. After cloning, add your imag
 
 - `public/img/decks/<deck>/characters/` – `char1.png` … `char10.png`
 - `public/img/decks/<deck>/tools/`
-- `public/img/decks/<deck>/bufs/` and `public/img/decks/<deck>/effects/`
+- `public/img/decks/<deck>/effects/`
+- `public/img/particles/` – add particle effect images (e.g., attack, magic, explosion, healing)
 - `public/img/decks/<deck>/card-backs/` – front background named `<deck-abbrev>-cb-default.webp`
 - `public/img/decks/<deck>/deck-backs/` – card back named `<deck-abbrev>-db-default.webp`
 - `public/img/mana/mana.png` – sprite sheet with six colored mana gems

--- a/public/img/decks/fJord-fishers/bufs/README.md
+++ b/public/img/decks/fJord-fishers/bufs/README.md
@@ -1,2 +1,0 @@
-# Fjord Fishers buffs
-Name files `ff_buf_<name>.png`.

--- a/public/img/decks/farm-vikings/bufs/README.md
+++ b/public/img/decks/farm-vikings/bufs/README.md
@@ -1,2 +1,0 @@
-# Farm Vikings buffs
-Drop buff icons here named `fv_buf_<effect>.png`.

--- a/public/img/decks/forest-beasts/bufs/README.md
+++ b/public/img/decks/forest-beasts/bufs/README.md
@@ -1,2 +1,0 @@
-# Forest Beasts buffs
-Name files `fb_buf_<name>.png`.

--- a/public/img/decks/north-beasts/bufs/README.md
+++ b/public/img/decks/north-beasts/bufs/README.md
@@ -1,2 +1,0 @@
-# North Beasts buffs
-Store buff icons as `nb_buf_<name>.png`.

--- a/public/img/particles/README.md
+++ b/public/img/particles/README.md
@@ -1,0 +1,3 @@
+# Particle effects
+
+Drop particle effect images here named after the effect, e.g. `attack.png`, `magic.png`, `explosion.png`, `healing.png`.


### PR DESCRIPTION
## Summary
- Remove outdated buff icon directories from each deck
- Introduce `public/img/particles` folder with README for future particle effect images
- Document particle folder in image asset README, leaving directory empty of placeholder images

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68aa1e5ef178832b8bd04ea5b900268d