### PR TITLE
Add card mechanics with harvest resource

### DIFF
--- a/js/ai/index.js
+++ b/js/ai/index.js
@@ -1,12 +1,12 @@
 export function aiTurn(ctx) {
   const { G, summon, renderAll, legalTarget, attackCard, attackFace, rand, newTurn } = ctx;
   const playable = G.aiHand
-    .filter((c) => c.cost <= G.aiMana)
+    .filter((c) => c.cost <= G.aiMana && c.harvestCost <= G.aiHarvest)
     .sort((a, b) => b.cost - a.cost);
   while (playable.length && G.aiBoard.length < 5 && G.aiMana > 0) {
     const c = playable.shift();
     const i = G.aiHand.findIndex((x) => x.id === c.id);
-    if (i > -1 && c.cost <= G.aiMana) {
+    if (i > -1 && c.cost <= G.aiMana && c.harvestCost <= G.aiHarvest) {
       G.aiHand.splice(i, 1);
       const stance =
         c.hp >= c.atk + 1
@@ -18,6 +18,7 @@ export function aiTurn(ctx) {
             : "attack";
       summon("ai", c, stance);
       G.aiMana -= c.cost;
+      G.aiHarvest -= c.harvestCost;
     }
   }
   renderAll();

--- a/js/game/card.js
+++ b/js/game/card.js
@@ -1,0 +1,66 @@
+export const ResourceType = Object.freeze({
+  MANA: 'mana',
+  ENERGIA: 'energia',
+  COLHEITA: 'colheita',
+});
+
+export const Keyword = Object.freeze({
+  FURIOSO: 'Furioso',
+  PROTETOR: 'Protetor',
+  PERCEPCAO: 'Percepção',
+  CURA: 'Cura',
+  BENCAO: 'Bênção',
+  CORVO: 'Corvo',
+  SERPENTE: 'Serpente',
+});
+
+export const CardType = Object.freeze({
+  UNIDADE: 'Unidade',
+  RITUAL: 'Ritual',
+  LENDA_MITICA: 'Lenda Mítica',
+});
+
+export const Faction = Object.freeze({
+  VIKINGS: 'Vikings',
+  FLORESTA: 'Floresta',
+  SOMBRAS: 'Sombras',
+  RUNICO: 'Rúnico',
+  MITICO: 'Mítico',
+});
+
+export class Card {
+  constructor({
+    nome,
+    faccao,
+    classe,
+    subclasse,
+    tipo = CardType.UNIDADE,
+    custo = 0,
+    atributos = {},
+    keywords = [],
+    efeito = '',
+    tags = [],
+  }) {
+    this.nome = nome;
+    this.faccao = faccao;
+    this.classe = classe;
+    this.subclasse = subclasse;
+    this.tipo = tipo;
+    // custo pode ser número (mana) ou objeto { mana, colheita }
+    this.custo = typeof custo === 'number'
+      ? { mana: custo, colheita: 0 }
+      : { mana: custo.mana ?? 0, colheita: custo.colheita ?? 0 };
+    this.atributos = {
+      ataque: atributos.ataque ?? 0,
+      defesa: atributos.defesa ?? 0,
+      percepcao: atributos.percepcao ?? 0,
+      espirito: atributos.espirito ?? 0,
+      furia: atributos.furia ?? 0,
+    };
+    this.keywords = keywords;
+    this.efeito = efeito;
+    this.tags = tags;
+  }
+}
+
+export const createCard = (data) => new Card(data);


### PR DESCRIPTION
## Summary
- define enums and Card class for new mechanics
- support alternative harvest resource in game state and UI
- update AI and player flow to spend harvest on play

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68aa44935c90832b8757c80bb2153ada