### PR TITLE
Implement automatic reconnection with 15-second timeout

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -720,3 +720,8 @@ color:#24040a}
 height:auto;
 display:block}
 .holo-logo{animation:logoBounce 2s ease-in-out infinite;filter:drop-shadow(0 0 6px rgba(0,255,255,.6))}
+
+/* Reconnect overlay */
+.reconnect-overlay{position:fixed;inset:0;display:none;place-items:center;background:radial-gradient(800px 400px at 50% 50%,rgba(255,255,255,.06),rgba(0,0,0,.8));z-index:2000}
+.reconnect-overlay.show{display:grid}
+.reconnect-box{background:linear-gradient(180deg,#121a44,#0c1230);border:1px solid #2b3a86;border-radius:16px;box-shadow:0 20px 50px rgba(0,0,0,.5);padding:22px 26px;display:flex;flex-direction:column;gap:12px;align-items:center;text-align:center}

--- a/public/index.html
+++ b/public/index.html
@@ -160,6 +160,14 @@
     </div>
   </div>
 
+  <!-- Reconnect popup -->
+  <div class="reconnect-overlay" id="reconnectOverlay">
+    <div class="reconnect-box">
+      <div id="reconnectMsg">Você perdeu a conexão com a sala.</div>
+      <div>Tentando reconectar... <span id="reconnectTimer">15</span>s</div>
+    </div>
+  </div>
+
   <script src="/socket.io/socket.io.js"></script>
   <script src="js/net-client.js"></script>
   <script src="js/multiplayer.js"></script>

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -373,7 +373,16 @@ els.playAgainBtn.addEventListener('click',()=>{if(window.isMultiplayer){showMult
 function handleMove(move){switch(move.type){case 'summon':{summon('ai',move.card,move.stance,true);applyBattlecryEffects('ai',move.effects||[]);G.aiMana-=move.card.cost;renderAll();break}case 'attack':{const a=G.aiBoard.find(x=>x.id===move.attackerId);const t=G.playerBoard.find(x=>x.id===move.targetId);if(a&&t)attackCard(a,t);break}case 'attackFace':{const a=G.aiBoard.find(x=>x.id===move.attackerId);if(a)attackFace(a,'player');break}}}
 function handleTurn(turn){if(turn==='end'){G.current='player';G.chosen=null;updateTargetingUI();newTurn()}}
 if(window.NET){NET.onOpponentDeckConfirmed(d=>{G.aiDeckChoice=d;if(window.mpState==='waitingDeck'){els.startGame.textContent='Iniciar';els.startGame.disabled=false;window.mpState='readyStart'}else{window.opponentConfirmed=true}});NET.onStartGame(()=>{els.start.style.display='none';els.wrap.style.display='block';initAudio();ensureRunning();stopMenuMusic();startGame(NET.isHost()?'player':'ai');window.mpState=null;window.opponentConfirmed=false});NET.onOpponentName(n=>{window.opponentName=n;updateOpponentLabel()})}
-if(window.NET){NET.onMove(handleMove);NET.onTurn(handleTurn);NET.onEmoji(e=>showEmoji('opponent',e));NET.onOpponentLeft(()=>{log('Oponente desconectou.');if(window.isMultiplayer&&els.wrap.style.display==='block')endGame(true);});NET.onOpponentResigned(()=>endGame(true));NET.onRematch(()=>{showMultiplayerDeckSelect();els.endOverlay.classList.remove('show')})}
+if(window.NET){
+NET.onMove(handleMove);
+NET.onTurn(handleTurn);
+NET.onEmoji(e=>showEmoji('opponent',e));
+NET.onOpponentDisconnected(()=>{if(window.showReconnect)window.showReconnect('Oponente desconectou. Aguardando reconexão...');});
+NET.onOpponentReconnected(()=>{if(window.hideReconnect)window.hideReconnect();});
+NET.onOpponentLeft(()=>{if(window.hideReconnect)window.hideReconnect();log('Oponente desconectou.');if(window.isMultiplayer&&els.wrap.style.display==='block')endGame(true);});
+NET.onOpponentResigned(()=>endGame(true));
+NET.onRematch(()=>{showMultiplayerDeckSelect();els.endOverlay.classList.remove('show')});
+}
 document.addEventListener('DOMContentLoaded',tryStartMenuMusicImmediate);
 document.addEventListener('visibilitychange',()=>{if(document.visibilityState==='visible')tryStartMenuMusicImmediate()});
 document.addEventListener('pointerdown',()=>{tryStartMenuMusicImmediate()},{once:true});

--- a/public/js/multiplayer.js
+++ b/public/js/multiplayer.js
@@ -115,6 +115,7 @@ document.addEventListener('DOMContentLoaded', () => {
     NET.onOpponentLeft(() => {
       clearInterval(reconTimer);
       statusEl.textContent = 'Oponente saiu.';
+      if (window.hideReconnect) window.hideReconnect();
     });
 
     NET.onConnectionError(() => {
@@ -123,13 +124,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
     let reconTimer = null;
     NET.onOpponentDisconnected(() => {
-      let t = 10;
-      statusEl.textContent = `Oponente desconectado. Reconnectando em ${t}s`;
+      let t = 15;
+      statusEl.textContent = `Oponente desconectado. Aguardando reconexão: ${t}s`;
+      if (window.showReconnect) window.showReconnect('Oponente desconectou. Aguardando reconexão...');
       clearInterval(reconTimer);
       reconTimer = setInterval(() => {
         t -= 1;
         if (t > 0) {
-          statusEl.textContent = `Oponente desconectado. Reconnectando em ${t}s`;
+          statusEl.textContent = `Oponente desconectado. Aguardando reconexão: ${t}s`;
         } else {
           clearInterval(reconTimer);
         }
@@ -139,6 +141,7 @@ document.addEventListener('DOMContentLoaded', () => {
     NET.onOpponentReconnected(() => {
       clearInterval(reconTimer);
       statusEl.textContent = 'Oponente reconectado.';
+      if (window.hideReconnect) window.hideReconnect();
     });
 
     NET.onRooms((rooms) => {

--- a/public/js/net-client.js
+++ b/public/js/net-client.js
@@ -8,6 +8,31 @@
   let role = null; // 'host' or 'guest'
   let roomCode = null;
 
+  const overlay = document.getElementById('reconnectOverlay');
+  const overlayMsg = document.getElementById('reconnectMsg');
+  const overlayTimer = document.getElementById('reconnectTimer');
+  let overlayInterval = null;
+
+  function showReconnect(message) {
+    if (!overlay) return;
+    overlayMsg.textContent = message;
+    let t = 15;
+    overlayTimer.textContent = t;
+    overlay.classList.add('show');
+    clearInterval(overlayInterval);
+    overlayInterval = setInterval(() => {
+      t -= 1;
+      if (t >= 0) overlayTimer.textContent = t;
+      if (t <= 0) clearInterval(overlayInterval);
+    }, 1000);
+  }
+
+  function hideReconnect() {
+    if (!overlay) return;
+    overlay.classList.remove('show');
+    clearInterval(overlayInterval);
+  }
+
   // store room code when hosting
   socket.on('hosted', (code) => {
     roomCode = code;
@@ -131,20 +156,25 @@
 
   socket.io.on('reconnect_failed', () => {
     console.error('Reconnection failed');
+    showReconnect('Falha ao reconectar.');
   });
 
   socket.on('disconnect', (reason) => {
     console.warn('Disconnected:', reason);
+    showReconnect('Você perdeu a conexão com a sala. Tentando reconectar...');
     if (reason === 'io server disconnect') {
       socket.connect();
     }
   });
 
   socket.on('reconnect', () => {
+    hideReconnect();
     if (roomCode && role) {
       socket.emit('rejoin', { room: roomCode, role });
     }
   });
 
   global.NET = NET;
+  global.showReconnect = showReconnect;
+  global.hideReconnect = hideReconnect;
 })(typeof window !== 'undefined' ? window : globalThis);

--- a/server.js
+++ b/server.js
@@ -191,7 +191,7 @@ io.on('connection', (socket) => {
       if (!info.host || info.players <= 0) {
         rooms.delete(room);
       }
-    }, 10000);
+    }, 15000);
 
     if (role === 'host') info.hostTimer = timer; else info.guestTimer = timer;
     socket.to(room).emit('opponentDisconnected');


### PR DESCRIPTION
## Summary
- Extend server-side disconnect grace period to 15 seconds
- Add reconnect popup with countdown and auto-rejoin logic
- Notify players when opponents disconnect or reconnect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68aa6544109c832b93ca4a103e3fa5a8