### PR TITLE
feat: display card classes and unify card sizing

### DIFF
--- a/js/game/index.js
+++ b/js/game/index.js
@@ -31,8 +31,39 @@ const KW = {
     BR1: "buffRandom1",
     BA1: "buffAlliesAtk1",
   };
+function deriveClassSub(name) {
+  const n = name.toLowerCase();
+  if (n.includes("berserker")) return { classe: "tank", subclasse: "Berserker" };
+  if (n.includes("guardião do véu") || n.includes("véu"))
+    return { classe: "control", subclasse: "Guardião do Véu" };
+  if (n.includes("guardião")) return { classe: "tank", subclasse: "Guardião" };
+  if (n.includes("uivante")) return { classe: "tank", subclasse: "Uivante" };
+  if (n.includes("caçador")) return { classe: "dps", subclasse: "Caçador" };
+  if (n.includes("runomante")) return { classe: "dps", subclasse: "Runomante" };
+  if (n.includes("serpente")) return { classe: "dps", subclasse: "Serpente" };
+  if (n.includes("curandeir")) return { classe: "support", subclasse: "Curandeiro" };
+  if (n.includes("totêmico") || n.includes("totemico"))
+    return { classe: "support", subclasse: "Totêmico" };
+  if (n.includes("sacerdote") || n.includes("tecelão"))
+    return { classe: "support", subclasse: "Tecelão" };
+  if (n.includes("xamã")) return { classe: "control", subclasse: "Xamã" };
+  if (n.includes("corvo")) return { classe: "control", subclasse: "Corvo" };
+  if (n.includes("guerreiro"))
+    return { classe: "dps", subclasse: "Guerreiro" };
+  if (n.includes("raider")) return { classe: "dps", subclasse: "Raider" };
+  if (n.includes("batalhador"))
+    return { classe: "dps", subclasse: "Batalhador" };
+  if (n.includes("mago") || n.includes("mistico"))
+    return { classe: "support", subclasse: "Mago" };
+  if (n.includes("sombras") || n.includes("encapuzado"))
+    return { classe: "control", subclasse: "Sombras" };
+  if (n.includes("navegador"))
+    return { classe: "support", subclasse: "Navegador" };
+  return { classe: "", subclasse: "" };
+}
 const makeCard = (a) => {
   const [n, e, t, atk, hp, cost, tx, k = 0, b = 0, harvest = 0] = a;
+  const cls = deriveClassSub(n || "");
   return {
     name: n,
     emoji: e,
@@ -44,6 +75,8 @@ const makeCard = (a) => {
     text: tx,
     kw: k ? k.split("|").map((x) => KW[x]) : [],
     battlecry: b ? BC[b] : void 0,
+    classe: cls.classe,
+    subclasse: cls.subclasse,
     id: uid(),
   };
 };
@@ -337,7 +370,20 @@ function cardNode(c, owner) {
   d.className = `card ${owner === "player" ? "me" : "enemy"} ${c.stance === "defense" ? "defense" : ""}`;
   d.dataset.id = c.id;
   const costText = `${c.cost}${c.harvestCost ? `🌾${c.harvestCost}` : ""}`;
-  d.innerHTML = `<div class="bg bg-${c.deck || "default"}"></div><div class="head"><span class="cost">${costText}</span><div class="name">${c.name}</div>${c.stance ? `<span class="badge ${c.stance === "defense" ? "def" : "atk"}">${c.stance === "defense" ? "🛡️" : "⚔️"}</span>` : ""}</div><div class="tribe">${c.tribe}</div><div class="art">${c.emoji}</div><div class="text">${(c.kw || []).map((k) => `<span class='keyword' data-tip='${k === "Protetor" ? "Enquanto houver Protetor ou carta em Defesa do lado do defensor, ataques devem mirá-los." : k === "Furioso" ? "Pode atacar no turno em que é jogada." : ""}' >${k}</span>`).join(" ")} ${c.text || ""}</div><div class="stats"><span class="gem atk">⚔️ ${c.atk}</span>${c.stance ? `<span class="stance-label ${c.stance}">${c.stance === 'defense' ? '🛡️' : '⚔️'}</span>` : ''}<span class="gem hp ${c.hp <= 2 ? "low" : ""}">❤️ ${c.hp}</span></div>`;
+  const kwTags = (c.kw || []).map(
+    (k) =>
+      `<span class='keyword' data-tip='${
+        k === "Protetor"
+          ? "Enquanto houver Protetor ou carta em Defesa do lado do defensor, ataques devem mirá-los."
+          : k === "Furioso"
+          ? "Pode atacar no turno em que é jogada."
+          : ""
+      }' >${k}</span>`
+  );
+  if (c.subclasse && c.classe) {
+    kwTags.push(`<span class='class-tag ${c.classe}'>${c.subclasse}</span>`);
+  }
+  d.innerHTML = `<div class="bg bg-${c.deck || "default"}"></div><div class="head"><span class="cost">${costText}</span><div class="name">${c.name}</div>${c.stance ? `<span class="badge ${c.stance === "defense" ? "def" : "atk"}">${c.stance === "defense" ? "🛡️" : "⚔️"}</span>` : ""}</div><div class="tribe">${c.tribe}</div><div class="art">${c.emoji}</div><div class="text">${kwTags.join(" ")} ${c.text || ""}</div><div class="stats"><span class="gem atk">⚔️ ${c.atk}</span>${c.stance ? `<span class="stance-label ${c.stance}">${c.stance === 'defense' ? '🛡️' : '⚔️'}</span>` : ''}<span class="gem hp ${c.hp <= 2 ? "low" : ""}">❤️ ${c.hp}</span></div>`;
   return d;
 }
 const hasGuard = (b) =>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,21 +1,23 @@
 :root{--bg:#0b1020;
---panel:#101833;
---panel2:#0f1430;
---accent:#7cc4ff;
---accent2:#ffd166;
---good:#4ade80;
---bad:#fb7185;
---mid:#a5b4fc;
---card:#141d3f;
---card2:#1a2454;
---text:#e6e9ff;
---muted:#a7b0d9;
---cb-vikings:url('/img/decks/farm-vikings/card-backs/fv-cb-default.webp');
---cb-pescadores:url('/img/decks/fJord-fishers/card-backs/jf-cb-default.webp');
---cb-floresta:url('/img/decks/forest-beasts/card-backs/fb-cb-default.webp');
---cb-animais:url('/img/decks/north-beasts/card-backs/nb-cb-default.webp');
---body-bg:url('/img/ui/backgrounds/fff-bg-01.webp');
---start-bg:url('/img/ui/backgrounds/fff-bg-01.webp')}
+ --panel:#101833;
+ --panel2:#0f1430;
+ --accent:#7cc4ff;
+ --accent2:#ffd166;
+ --good:#4ade80;
+ --bad:#fb7185;
+ --mid:#a5b4fc;
+ --card:#141d3f;
+ --card2:#1a2454;
+ --text:#e6e9ff;
+ --muted:#a7b0d9;
+ --card-w:176px;
+ --card-h:240px;
+ --cb-vikings:url('/img/decks/farm-vikings/card-backs/fv-cb-default.webp');
+ --cb-pescadores:url('/img/decks/fJord-fishers/card-backs/jf-cb-default.webp');
+ --cb-floresta:url('/img/decks/forest-beasts/card-backs/fb-cb-default.webp');
+ --cb-animais:url('/img/decks/north-beasts/card-backs/nb-cb-default.webp');
+ --body-bg:url('/img/ui/backgrounds/fff-bg-01.webp');
+ --start-bg:url('/img/ui/backgrounds/fff-bg-01.webp')}
 *{box-sizing:border-box}
 html,body{height:100%;overflow:auto}
 body{margin:0;
@@ -90,7 +92,7 @@ text-transform:uppercase;
 letter-spacing:.8px;
 margin:6px 0 2px}
 .board{display:grid;
- grid-template-columns:repeat(5,176px);
+ grid-template-columns:repeat(5,var(--card-w));
  gap:14px;
  background:linear-gradient(180deg,rgba(255,255,255,.03),rgba(255,255,255,0));
  border-radius:16px;
@@ -100,20 +102,20 @@ margin:6px 0 2px}
  position:relative;
  overflow:visible;
  margin:12px 0;
-width:calc(5*176px + 4*14px + 24px)}
+width:calc(5*var(--card-w) + 4*14px + 24px)}
 #aiBoard,#playerBoard{margin:0 auto}
 .row{display:flex;gap:14px;align-items:flex-start;flex:1;justify-content:center}
 .row .board{flex:0 0 auto}
 .hand{position:relative;height:220px;margin:20px 0 0;flex:0 0 auto;overflow:visible}
-.hand .card{position:absolute;top:0;width:176px;transition:transform .2s,box-shadow .2s}
+.hand .card{position:absolute;top:0;width:var(--card-w);transition:transform .2s,box-shadow .2s}
 .hand .card::before{opacity:0}
-.hand .card:hover{transform:translateY(-24px)}
-.hand .card.chosen{transform:translateY(-80px);box-shadow:0 0 12px var(--accent),0 16px 30px rgba(0,0,0,.45)}
+.hand .card:hover{transform:translateY(-24px) scale(1.06)}
+.hand .card.chosen{transform:translateY(-80px) scale(1.3);box-shadow:0 0 12px var(--accent),0 16px 30px rgba(0,0,0,.45)}
 .hand .card.chosen::before{animation:foilHue 1.2s linear infinite}
 .hand .card.chosen::after{opacity:.3}
 @keyframes foilHue{from{filter:hue-rotate(0deg);}to{filter:hue-rotate(360deg);}}
 @keyframes stanceHolo{from{filter:hue-rotate(0deg) drop-shadow(0 0 6px rgba(0,255,255,.6));}to{filter:hue-rotate(360deg) drop-shadow(0 0 6px rgba(0,255,255,.6));}}
-.card{width:100%;max-width:176px;aspect-ratio:176/240;
+.card{width:100%;max-width:var(--card-w);aspect-ratio:176/240;
  min-height:auto;
  background:linear-gradient(180deg,var(--card2),var(--card));
  border-radius:18px;
@@ -209,8 +211,8 @@ transform:translate3d(0,0,0) scale(1.02);
 transition:transform .15s ease}
 .card>*:not(.bg){position:relative;
 z-index:1}
-#playerBoard .card:hover{transform:translateY(-6px);
-box-shadow:0 16px 30px rgba(0,0,0,.45),0 0 0 2px rgba(124,196,255,.15) inset}
+#playerBoard .card:hover{transform:translateY(-6px) scale(1.03);
+ box-shadow:0 16px 30px rgba(0,0,0,.45),0 0 0 2px rgba(124,196,255,.15) inset}
 .card.tilted{transform:rotateX(var(--rX)) rotateY(var(--rY))}
 .card::before{content:"";
 position:absolute;
@@ -435,8 +437,8 @@ white-space:nowrap}
 @media (max-width:720px){.log-wrap{width:200px}}
 .pile{display:grid;
  place-items:center;
- width:176px;
- height:240px;
+ width:var(--card-w);
+ height:var(--card-h);
  border-radius:10px;
  border:1px dashed #31408b;
  background:linear-gradient(180deg,rgba(255,255,255,.03),rgba(255,255,255,0));

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -107,8 +107,8 @@ width:calc(5*176px + 4*14px + 24px)}
 .hand{position:relative;height:220px;margin:20px 0 0;flex:0 0 auto;overflow:visible}
 .hand .card{position:absolute;top:0;width:176px;transition:transform .2s,box-shadow .2s}
 .hand .card::before{opacity:0}
-.hand .card:hover{transform:translateY(-24px) scale(1.06)}
-.hand .card.chosen{transform:translateY(-80px) scale(1.3);box-shadow:0 0 12px var(--accent),0 16px 30px rgba(0,0,0,.45)}
+.hand .card:hover{transform:translateY(-24px)}
+.hand .card.chosen{transform:translateY(-80px);box-shadow:0 0 12px var(--accent),0 16px 30px rgba(0,0,0,.45)}
 .hand .card.chosen::before{animation:foilHue 1.2s linear infinite}
 .hand .card.chosen::after{opacity:.3}
 @keyframes foilHue{from{filter:hue-rotate(0deg);}to{filter:hue-rotate(360deg);}}
@@ -166,8 +166,8 @@ height:auto;
 font-size:48px;
 position:relative}
 .art::after{content:"";position:absolute;inset:0;background:linear-gradient(115deg,rgba(255,255,255,.25),rgba(255,255,255,0) 60%);mix-blend-mode:screen;pointer-events:none;opacity:.2}
-.text{font-size:12px;color:#d9e3ff;background:#0e1435;border:1px solid #25306a;border-radius:10px;padding:4px;margin:0;max-width:100%;word-break:break-word;box-sizing:border-box;white-space:normal;overflow:hidden;height:auto}
-.text::after{content:"";display:block;clear:both}
+.text{font-size:12px;color:#d9e3ff;background:#0e1435;border:1px solid #25306a;border-radius:10px;padding:4px;margin:0;max-width:100%;word-break:break-word;box-sizing:border-box;white-space:normal;overflow:hidden;height:auto;display:flex;align-items:center;flex-wrap:wrap;gap:6px}
+.text::after{content:""}
 .stats{display:flex;justify-content:space-between;align-items:center;margin:0;min-height:26px;align-self:end;gap:4px}
 .stats .stance-label{margin:0 4px;text-align:center}
 
@@ -187,9 +187,8 @@ background:linear-gradient(180deg,#6342b6,#3b1f7e);
 padding:2px 6px;
 border-radius:999px;
 font-size:11px;
-margin-right:6px;
 border:1px solid rgba(255,255,255,.12)}
-.class-tag{display:inline-block;float:right;margin-left:auto;padding:2px 6px;border-radius:999px;font-size:11px;border:1px solid rgba(255,255,255,.12);color:#fff}
+.class-tag{display:inline-block;margin-left:auto;padding:2px 6px;border-radius:999px;font-size:11px;border:1px solid rgba(255,255,255,.12);color:#fff}
 .class-tag.tank{background:#2a5f3a}
 .class-tag.dps{background:#5f2a2a}
 .class-tag.support{background:#2a4a5f}
@@ -210,9 +209,9 @@ transform:translate3d(0,0,0) scale(1.02);
 transition:transform .15s ease}
 .card>*:not(.bg){position:relative;
 z-index:1}
-#playerBoard .card:hover{transform:translateY(-6px) scale(1.03);
+#playerBoard .card:hover{transform:translateY(-6px);
 box-shadow:0 16px 30px rgba(0,0,0,.45),0 0 0 2px rgba(124,196,255,.15) inset}
-.card.tilted{transform:rotateX(var(--rX)) rotateY(var(--rY)) scale(1.03)}
+.card.tilted{transform:rotateX(var(--rX)) rotateY(var(--rY))}
 .card::before{content:"";
 position:absolute;
 inset:-1px;

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -17,8 +17,30 @@ const KW={P:'Protetor',F:'Furioso'},
       BC={D1:'draw1',H2:'heal2',P1:'ping1',BR1:'buffRandom1',BA1:'buffAlliesAtk1',M1:'mana1',SM:'sacMana'},
       BC_NAMES={draw1:'Percepção',heal2:'Cura',ping1:'Golpe',buffRandom1:'Benção',buffAlliesAtk1:'Comando',mana1:'Canalizar',sacMana:'Sacrifício'},
       BC_TIPS={draw1:'Compra 1 carta ao entrar',heal2:'Cura 2 de um aliado ao entrar',ping1:'Causa 1 de dano aleatório ao entrar',buffRandom1:'Concede +1/+1 a um aliado aleatório ao entrar',buffAlliesAtk1:'Aliados ganham +1 ATK',mana1:'Ganha 1 de mana ao entrar',sacMana:'Sacrifica um aliado e ganha mana igual ao custo'};
-const normalizeCardName=f=>f.replace(/\.[^.]+$/,'').replace(/^\d+[_-]?/,'').replace(/[-_]+/g,' ').replace(/\b\w/g,c=>c.toUpperCase());
-const makeCard=a=>{const[n,e,t,atk,hp,cost,tx,k=0,b=0,i]=a;let name=n;if(!name&&typeof i==='string')name=normalizeCardName(i);return{name,emoji:e,tribe:t,atk,hp,cost,text:tx,kw:k?k.split('|').map(x=>KW[x]):[],battlecry:b?BC[b]:void 0,icon:i,id:uid()}};
+const normalizeCardName=f=>f.replace(/\.[^.]+$/,'').replace(/^nb[_-]?/i,'').replace(/^\d+[_-]?/,'').replace(/[-_]+/g,' ').replace(/\b\w/g,c=>c.toUpperCase());
+function deriveClassSub(name){
+  const n=name.toLowerCase();
+  if(n.includes('berserker')) return {classe:'tank', subclasse:'Berserker'};
+  if(n.includes('guardião do véu')||n.includes('véu')) return {classe:'control', subclasse:'Guardião do Véu'};
+  if(n.includes('guardião')) return {classe:'tank', subclasse:'Guardião'};
+  if(n.includes('uivante')) return {classe:'tank', subclasse:'Uivante'};
+  if(n.includes('caçador')) return {classe:'dps', subclasse:'Caçador'};
+  if(n.includes('runomante')) return {classe:'dps', subclasse:'Runomante'};
+  if(n.includes('serpente')) return {classe:'dps', subclasse:'Serpente'};
+  if(n.includes('curandeir')) return {classe:'support', subclasse:'Curandeiro'};
+  if(n.includes('totêmico')||n.includes('totemico')) return {classe:'support', subclasse:'Totêmico'};
+  if(n.includes('sacerdote')||n.includes('tecelão')) return {classe:'support', subclasse:'Tecelão'};
+  if(n.includes('xamã')) return {classe:'control', subclasse:'Xamã'};
+  if(n.includes('corvo')) return {classe:'control', subclasse:'Corvo'};
+  if(n.includes('guerreiro')) return {classe:'dps', subclasse:'Guerreiro'};
+  if(n.includes('raider')) return {classe:'dps', subclasse:'Raider'};
+  if(n.includes('batalhador')) return {classe:'dps', subclasse:'Batalhador'};
+  if(n.includes('mago')||n.includes('mistico')) return {classe:'support', subclasse:'Mago'};
+  if(n.includes('sombras')||n.includes('encapuzado')) return {classe:'control', subclasse:'Sombras'};
+  if(n.includes('navegador')) return {classe:'support', subclasse:'Navegador'};
+  return {classe:'', subclasse:''};
+}
+const makeCard=a=>{const[n,e,t,atk,hp,cost,tx,k=0,b=0,i]=a;let name=n;if(!name&&typeof i==='string')name=normalizeCardName(i);const cls=deriveClassSub(name);return{name,emoji:e,tribe:t,atk,hp,cost,text:tx,kw:k?k.split('|').map(x=>KW[x]):[],battlecry:b?BC[b]:void 0,icon:i,classe:cls.classe,subclasse:cls.subclasse,id:uid()}};
 const DECK_IMAGES={
   vikings:['1_Guerreiro_Loiro','2_Guerreiro_Esqueleto','3_Guerreiro_Rubro','4_Mago_Elder','5_Raider_Mascara','6_Guerreiro_Machado','7_Sombras_Encapuzado','8_Guerreiro_Espada','9_Raider_Mascara_Sombra','10_Mago_Elder_Sombra'],
   pescadores:['1_Fogueira_Viking','2_Mistico_Encapuzado','3_Drakkar','4_Guerreiro_do_Escudo','5_Estandarte_do_Cla','6_Guerreiro_das_Runas','7_Guardiao_do_Machado','8_Batalhador_Duplo','9_Navegador','10_Batalhador'],
@@ -26,7 +48,7 @@ const DECK_IMAGES={
   animais:['nb-alce-bravo','nb-coelho-escudeiro','nb-coruja-ancia','nb-coruja-sabia','nb-esquilo-viking','nb-guerreiro-cervo','nb-morcego-noturno','nb-raposa-espadachim','nb-urso-guardiao']
 };
 function deriveStatsFromName(name){const n=name.toLowerCase();let atk=3,hp=3,kw='',bc='',text='';if(/guard/i.test(n)){atk=2;hp=5;kw='P';text='Protetor'}else if(/mago|mistico/.test(n)){atk=2;hp=3;bc='H2';text='Entra: cura 2'}else if(/guerreiro|batalhador|raider|lobo|raposa/.test(n)){atk=4;hp=2;kw='F';text='Furioso'}else if(/fogueira|estandarte/.test(n)){atk=1;hp=1;bc='BR1';text='Entra: +1/+1 aleatório'}else if(/coruja/.test(n)){atk=1;hp=2;bc='D1';text='Entra: compre 1'}else if(/serpente/.test(n)){atk=5;hp=4}else if(/alce|urso|bode|cervo/.test(n)){atk=4;hp=5;kw='P';text='Protetor'}return{atk,hp,kw,bc,text};}
-function buildDeck(key){const tribe=key==='vikings'||key==='pescadores'?'Viking':'Animal';return (DECK_IMAGES[key]||[]).map(fn=>{const name=normalizeCardName(fn);const s=deriveStatsFromName(fn);const cost=Math.max(1,Math.round((s.atk+s.hp)/2));return [name,'',tribe,s.atk,s.hp,cost,s.text,s.kw,s.bc,fn];});}
+function buildDeck(key){const tribe=key==='vikings'||key==='pescadores'?'Viking':'Animal';return (DECK_IMAGES[key]||[]).map(fn=>{const name=normalizeCardName(fn);const s=deriveStatsFromName(name);const cost=Math.max(1,Math.round((s.atk+s.hp)/2));return [name,'',tribe,s.atk,s.hp,cost,s.text,s.kw,s.bc,fn];});}
 const TEMPLATES={vikings:buildDeck('vikings'),animais:buildDeck('animais'),pescadores:buildDeck('pescadores'),floresta:buildDeck('floresta')};
 const HUMAN=['vikings','pescadores'],BEAST=['animais','floresta'];
 const G={playerHP:30,aiHP:30,turn:0,playerMana:0,playerManaCap:0,aiMana:0,aiManaCap:0,current:'player',playerDeck:[],aiDeck:[],playerHand:[],aiHand:[],playerBoard:[],aiBoard:[],playerDiscard:[],aiDiscard:[],chosen:null,playerDeckChoice:'vikings',aiDeckChoice:'animais',customDeck:null};
@@ -87,22 +109,6 @@ function setDeckBacks(){
   apply(G.aiDeckChoice,'aiDrawPile','aiDiscardPile');
 }
 
-function determineClass(c){
-  const n=c.name.toLowerCase();
-  if(n.includes('berserker')) return {name:'Berserker',group:'tank'};
-  if(n.includes('guardião do véu')||n.includes('véu')) return {name:'Guardião do Véu',group:'control'};
-  if(n.includes('guardião')) return {name:'Guardião',group:'tank'};
-  if(n.includes('uivante')) return {name:'Uivante',group:'tank'};
-  if(n.includes('caçador')) return {name:'Caçador',group:'dps'};
-  if(n.includes('runomante')) return {name:'Runomante',group:'dps'};
-  if(n.includes('serpente')) return {name:'Serpente',group:'dps'};
-  if(n.includes('curandeir')) return {name:'Curandeiro',group:'support'};
-  if(n.includes('totêmico')||n.includes('totemico')) return {name:'Totêmico',group:'support'};
-  if(n.includes('sacerdote')||n.includes('tecelão')) return {name:'Tecelão',group:'support'};
-  if(n.includes('xamã')) return {name:'Xamã',group:'control'};
-  if(n.includes('corvo')) return {name:'Corvo',group:'control'};
-  return null;
-}
 // deck builder DOM (may be null if builder UI not present)
 const poolEl=$('#pool'), chosenEl=$('#chosen'), countEl=$('#countDeck'), curveEl=$('#curve');
 // safe builder functions (no-ops if UI not present)
@@ -151,7 +157,7 @@ function cardNode(c,owner,onBoard=false){
     const n=BC_NAMES[c.battlecry], tip=BC_TIPS[c.battlecry];
     if(n)kwTags.push(`<span class='keyword' data-tip='${tip}' title='${tip}'>${n}</span>`);
   }
-  const cls=determineClass(c);if(cls)kwTags.push(`<span class='class-tag ${cls.group}'>${cls.name}</span>`);
+  if(c.subclasse&&c.classe)kwTags.push(`<span class='class-tag ${c.classe}'>${c.subclasse}</span>`);
   const text=c.text||'';
   const tip=text&&!kwTags.some(s=>s.includes('>'+text.trim()+'<'))?text:'';
   d.innerHTML=`<div class="bg bg-${c.deck||'default'}"></div>


### PR DESCRIPTION
## Summary
- map additional card name patterns to classes and subclasses
- show class tags to the right of abilities with flex layout
- remove hover scaling so card size stays consistent across zones

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68aa6a0aaf38832ba750675745930e34