### PR TITLE
Ensure deck and discard piles match card size

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -31,7 +31,7 @@ padding-bottom:8px}
 h1{margin:0 0 12px;
 font-size:clamp(22px,4vw,36px);
 letter-spacing:.5px}
-.wrap{max-width:1600px;margin:0 auto;padding:16px 24px;min-height:100vh;display:flex;flex-direction:column}
+.wrap{max-width:calc(7*var(--card-w) + 6*14px + 72px);margin:0 auto;padding:16px 24px;min-height:100vh;display:flex;flex-direction:column}
 .sub{color:var(--muted);
 margin-bottom:18px}
 .btn{cursor:pointer;
@@ -441,7 +441,8 @@ white-space:nowrap}
  width:var(--card-w);
  height:var(--card-h);
  border-radius:18px;
- position:relative}
+ position:relative;
+ flex:0 0 var(--card-w)}
 .pile img{
  display:block;
  width:100%;


### PR DESCRIPTION
## Summary
- Expand main wrap width to accommodate deck and discard piles without shrinking
- Prevent deck/discard piles from flex shrinking so their images match card dimensions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68aaa9a547fc832b9f329ee0951d635a