### PR TITLE
Add Convergentes da Aurora deck with new mechanics

### DIFF
--- a/js/ai/index.js
+++ b/js/ai/index.js
@@ -26,7 +26,7 @@ export function aiTurn(ctx) {
   function next() {
     if (!attackers.length) {
       G.current = "player";
-      newTurn();
+      newTurn("ai");
       return;
     }
     const a = attackers.shift();

--- a/js/game/card.js
+++ b/js/game/card.js
@@ -12,6 +12,8 @@ export const Keyword = Object.freeze({
   BENCAO: 'Bênção',
   CORVO: 'Corvo',
   SERPENTE: 'Serpente',
+  ABSORVER: 'Absorver',
+  MUTAVEL: 'Mutável',
 });
 
 export const CardType = Object.freeze({

--- a/js/game/index.js
+++ b/js/game/index.js
@@ -23,6 +23,8 @@ const KW = {
     B: Keyword.BENCAO,
     CV: Keyword.CORVO,
     S: Keyword.SERPENTE,
+    A: Keyword.ABSORVER,
+    M: Keyword.MUTAVEL,
   },
   BC = {
     D1: "draw1",
@@ -175,6 +177,13 @@ const TEMPLATES = {
       "",
       "BA1",
     ],
+    ["Rastreador do Fiorde", "", "Viking", 1, 2, 1, "Entra: compre 1", "", "D1"],
+    ["Ceifeira Ágil", "", "Viking", 3, 2, 2, "Furioso", "F"],
+    ["Defensor do Arado", "", "Viking", 1, 5, 3, "Protetor", "P"],
+    ["Runomante Rural", "", "Viking", 2, 3, 3, "Entra: +1/+1 aleatório", "", "BR1"],
+    ["Guerreiro da Foice", "", "Viking", 5, 3, 4, "Furioso", "F"],
+    ["Guardiã do Celeiro", "", "Viking", 3, 6, 5, "Protetor", "P"],
+    ["Senhor do Campo", "", "Viking", 6, 6, 6, "Aliados +1 ATK", "", "BA1"],
   ],
   animais: [
     ["Urso Pardo", "🐻", "Animal", 6, 6, 5, "Protetor", "P"],
@@ -182,7 +191,6 @@ const TEMPLATES = {
     ["Javali Selvagem", "🐗", "Animal", 3, 2, 2, "Impulsivo"],
     ["Cervo Nobre", "🦌", "Animal", 4, 5, 4, "Resistente"],
     ["Coruja Sábia", "🦉", "Animal", 1, 2, 1, "Entra: compre 1", "", "D1"],
-    ["Cavalo de Guerra", "🐴", "Animal", 3, 3, 3, "Confiável"],
     ["Cabra da Montanha", "🐐", "Animal", 2, 3, 2, "Protetor", "P"],
     ["Águia do Norte", "🦅", "Animal", 5, 3, 4, "Veloz"],
     ["Urso Polar", "🐻‍❄️", "Animal", 7, 7, 6, "Gigante"],
@@ -202,6 +210,12 @@ const TEMPLATES = {
     ],
     ["Caribu Selvagem", "", "Animal", 4, 5, 4, "Protetor", "P"],
     ["Texugo Ártico", "", "Animal", 3, 2, 2, "Furioso", "F"],
+    ["Foca do Gelo", "", "Animal", 2, 3, 2, "Entra: compre 1", "", "D1"],
+    ["Lobo Uivante", "", "Animal", 4, 3, 4, "Furioso", "F"],
+    ["Raposa Escarlate", "", "Animal", 3, 2, 2, "Furioso", "F"],
+    ["Touro das Neves", "", "Animal", 5, 5, 5, "Protetor", "P"],
+    ["Corvo Astuto", "", "Animal", 1, 2, 2, "Entra: compre 1", "", "D1"],
+    ["Fera das Cavernas", "", "Animal", 6, 6, 6, "Furioso", "F"],
   ],
   pescadores: [
     ["Grumete do Fiorde", "👦🎣", "Viking", 1, 1, 1, "Aprendiz"],
@@ -287,6 +301,13 @@ const TEMPLATES = {
       "",
       "P1",
     ],
+    ["Aprendiz de Rede", "", "Viking", 1, 2, 1, "Entra: compre 1", "", "D1"],
+    ["Baleeiro Leal", "", "Viking", 2, 4, 3, "Protetor", "P"],
+    ["Atirador do Convés", "", "Viking", 3, 2, 2, "Entra: dano 1 aleatório", "", "P1"],
+    ["Sacerdote das Ondas", "", "Viking", 2, 3, 3, "Entra: cura 2", "", "H2"],
+    ["Corsário Intrépido", "", "Viking", 4, 2, 3, "Furioso", "F"],
+    ["Patrulheiro Náutico", "", "Viking", 3, 5, 4, "Protetor", "P"],
+    ["Almirante do Fiorde", "", "Viking", 5, 5, 6, "Aliados +1 ATK", "", "BA1"],
   ],
   floresta: [
     ["Urso Negro", "🐻", "Animal", 5, 5, 5, "Protetor", "P"],
@@ -312,6 +333,113 @@ const TEMPLATES = {
       "BR1",
     ],
     ["Javali Voraz", "", "Animal", 5, 3, 4, "Furioso", "F"],
+    ["Lebre da Névoa", "", "Animal", 1, 1, 1, "Veloz"],
+    ["Guardião da Clareira", "", "Animal", 2, 5, 3, "Protetor", "P"],
+    ["Raposa Sombria", "", "Animal", 3, 2, 2, "Furioso", "F"],
+    ["Urso Musgoso", "", "Animal", 5, 6, 5, "Protetor", "P"],
+    ["Coruja Mensageira", "", "Animal", 1, 2, 2, "Entra: compre 1", "", "D1"],
+    ["Cervo das Runas", "", "Animal", 3, 3, 3, "Entra: +1/+1 aleatório", "", "BR1"],
+    ["Javali Espinhoso", "", "Animal", 5, 3, 4, "Furioso", "F"],
+  ],
+  convergentes: [
+    [
+      "Neófito Convergente",
+      "🌀",
+      "Convergente",
+      2,
+      2,
+      1,
+      "Entra: copia uma palavra-chave de um aliado",
+      "A",
+    ],
+    ["Proteiforme da Aurora", "🌈", "Convergente", 3, 3, 3, "", "M"],
+    ["Guardião Quimérico", "🛡️🐺", "Convergente", 2, 6, 4, "", "P|M"],
+    ["Raider Metamorfo", "⚔️🌊", "Convergente", 4, 2, 3, "", "F|M"],
+    [
+      "Runa Voraz",
+      "🌀🪨",
+      "Convergente",
+      1,
+      4,
+      2,
+      "Ganha +1 ATK sempre que um aliado morre.",
+    ],
+    [
+      "Totem Absorvente",
+      "🪵🌀",
+      "Convergente",
+      0,
+      5,
+      3,
+      "Fim de turno: copia uma palavra-chave de um inimigo aleatório.",
+      "P",
+    ],
+    [
+      "Arauto da Aurora",
+      "✨👑",
+      "Convergente",
+      5,
+      5,
+      6,
+      "Se você copiou ≥3 palavras-chave na partida, aliados +1/+1.",
+    ],
+    [
+      "Sombra Rúnica",
+      "🌘🌀",
+      "Convergente",
+      3,
+      3,
+      3,
+      "Sempre que absorver, ganha +1/+1.",
+      "A",
+    ],
+    [
+      "Guerreiro Sincrético",
+      "⚔️🛡️",
+      "Convergente",
+      4,
+      4,
+      4,
+      "Entra: escolha Furioso ou Protetor; ganha essa palavra-chave.",
+    ],
+    ["Lince Metamórfico", "🐱🌈", "Convergente", 3, 2, 2, "", "F|M"],
+    [
+      "Capataz de Runas",
+      "🌀⚙️",
+      "Convergente",
+      2,
+      4,
+      3,
+      "Ao absorver, causa 1 de dano a todos os inimigos.",
+      "A",
+    ],
+    [
+      "Colosso Alquímico",
+      "🗿🌈",
+      "Convergente",
+      7,
+      7,
+      7,
+      "Entra: copia uma palavra-chave de cada aliado.",
+      "M",
+    ],
+    [
+      "Essência Convergente",
+      "💠",
+      "Convergente",
+      0,
+      0,
+      1,
+      "Entra com ATK/HP iguais ao nº de palavras-chave diferentes que você controla.",
+      "A",
+    ],
+    ["Discípulo Maleável", "", "Convergente", 1, 3, 2, "", "M"],
+    ["Sentinela Vórtice", "", "Convergente", 2, 4, 3, "Entra: copia uma palavra-chave de um aliado", "P|A"],
+    ["Tecelão Cambiante", "", "Convergente", 2, 3, 3, "Entra: compre 1", "A", "D1"],
+    ["Eco Mutante", "", "Convergente", 4, 4, 4, "", "A|M"],
+    ["Bruto Assimilador", "", "Convergente", 5, 5, 5, "", "A|M"],
+    ["Sábio Prismal", "", "Convergente", 3, 5, 4, "Entra: +1/+1 aleatório", "M", "BR1"],
+    ["Avatar Mutagênico", "", "Convergente", 6, 6, 6, "", "M"],
   ],
 };
 const ALL_DECKS = Object.keys(TEMPLATES);
@@ -384,6 +512,7 @@ function renderPool() {
     ...TEMPLATES.animais,
     ...TEMPLATES.pescadores,
     ...TEMPLATES.floresta,
+    ...TEMPLATES.convergentes,
   ];
   if (!poolEl) return;
   poolEl.innerHTML = "";
@@ -497,6 +626,10 @@ function cardNode(c, owner) {
           ? "Enquanto houver Protetor ou carta em Defesa do lado do defensor, ataques devem mirá-los."
           : k === "Furioso"
           ? "Pode atacar no turno em que é jogada."
+          : k === "Absorver"
+          ? "Ao entrar, copia uma palavra-chave de um aliado."
+          : k === "Mutável"
+          ? "No fim do turno, troca ATK e HP."
           : ""
       }' >${k}</span>`
   );
@@ -820,7 +953,8 @@ function draw(who, n = 1) {
     els.discardCount.textContent = G.playerDiscard.length;
   }
 }
-function newTurn() {
+function newTurn(prev) {
+  if (prev) applyEndTurnEffects(prev);
   if (G.current === "player") {
     G.playerManaCap = clamp(G.playerManaCap + 1, 0, 10);
     G.playerMana = G.playerManaCap;
@@ -843,7 +977,7 @@ function endTurn() {
   G.current = "ai";
   G.chosen = null;
   updateTargetingUI();
-  newTurn();
+  newTurn("player");
   sfx("end");
   setTimeout(
     () =>
@@ -887,6 +1021,7 @@ function summon(side, c, st = "attack") {
     `${side === "player" ? "Você" : "Inimigo"} jogou ${c.name} em modo ${st === "defense" ? "defesa" : "ataque"}.`,
   );
   triggerBattlecry(side, c);
+  if (c.kw.includes("Absorver")) absorbFromAlly(side, c);
   if (st === "defense") setTimeout(() => animateDefense(c.id), 30);
 }
 function triggerBattlecry(side, c) {
@@ -955,6 +1090,60 @@ function triggerBattlecry(side, c) {
         if (allies.length) log(`${c.name}: aliados ganharam +1 de ataque.`);
       }
       break;
+  }
+}
+
+function absorbFromAlly(side, c) {
+  const board = side === "player" ? G.playerBoard : G.aiBoard;
+  const allies = board.filter((x) => x.id !== c.id && x.kw && x.kw.length);
+  if (!allies.length) return;
+  const src = rand(allies);
+  const choices = src.kw.filter((k) => !c.kw.includes(k));
+  if (!choices.length) return;
+  const kw = rand(choices);
+  c.kw.push(kw);
+  particleOnCard(c.id, "magic");
+  fxTextOnCard(c.id, kw, "buff");
+  log(`${c.name} absorveu ${kw}.`);
+  if (c.name === "Sombra Rúnica") {
+    c.atk += 1;
+    c.hp += 1;
+  }
+  if (c.name === "Capataz de Runas") {
+    const foes = side === "player" ? G.aiBoard : G.playerBoard;
+    foes.forEach((t) => {
+      damageMinion(t, 1);
+      particleOnCard(t.id, "attack");
+      fxTextOnCard(t.id, "-1", "dmg");
+    });
+    checkDeaths();
+  }
+}
+
+function applyEndTurnEffects(side) {
+  const board = side === "player" ? G.playerBoard : G.aiBoard;
+  const foeBoard = side === "player" ? G.aiBoard : G.playerBoard;
+  for (const c of board) {
+    if (c.kw.includes("Mutável")) {
+      const atk = c.atk;
+      c.atk = c.hp;
+      c.hp = atk;
+      fxTextOnCard(c.id, "⇆", "buff");
+    }
+    if (c.name === "Totem Absorvente") {
+      const foes = foeBoard.filter((f) => f.kw && f.kw.length);
+      if (foes.length) {
+        const src = rand(foes);
+        const opts = src.kw.filter((k) => !c.kw.includes(k));
+        if (opts.length) {
+          const kw = rand(opts);
+          c.kw.push(kw);
+          particleOnCard(c.id, "magic");
+          fxTextOnCard(c.id, kw, "buff");
+          log(`${c.name} absorveu ${kw} de ${src.name}.`);
+        }
+      }
+    }
   }
 }
 function updateTargetingUI() {

--- a/public/index.html
+++ b/public/index.html
@@ -35,6 +35,7 @@
         <button class="btn deckbtn" data-deck="animais">🐺 Bestas do Norte<div class="ribbon">Ataque bruto</div><span class="view-cards" data-deck="animais" data-tip="Ver cartas" aria-label="Ver cartas">📖</span></button>
         <button class="btn deckbtn" data-deck="pescadores">🎣 Pescadores do Fiorde<div class="ribbon">Suporte e bônus</div><span class="view-cards" data-deck="pescadores" data-tip="Ver cartas" aria-label="Ver cartas">📖</span></button>
         <button class="btn deckbtn" data-deck="floresta">🌲 Feras da Floresta<div class="ribbon">Pressão constante</div><span class="view-cards" data-deck="floresta" data-tip="Ver cartas" aria-label="Ver cartas">📖</span></button>
+        <button class="btn deckbtn" data-deck="convergentes">🌀 Convergentes da Aurora<div class="ribbon">Absorção e metamorfose</div><span class="view-cards" data-deck="convergentes" data-tip="Ver cartas" aria-label="Ver cartas">📖</span></button>
         <button class="btn deckbtn" data-deck="custom">🧩 Deck Personalizado<div class="ribbon">Monte seu baralho</div><span class="view-cards" data-deck="custom" data-tip="Ver cartas" aria-label="Ver cartas">📖</span></button>
       </div>
       <div id="deckBuilder" style="display:none">
@@ -95,6 +96,7 @@
           <button class="fbtn" data-deck="animais">Animais</button>
           <button class="fbtn" data-deck="pescadores">Pescadores</button>
           <button class="fbtn" data-deck="floresta">Floresta</button>
+          <button class="fbtn" data-deck="convergentes">Convergentes</button>
         </div>
       </div>
       <div class="ency-grid" id="encyGrid"></div>

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -12,8 +12,8 @@ function setSfxVolume(v){sfxVolume=clamp(v,0,1);if(master)master.gain.value=sfxM
 window.setMusicVolume=setMusicVolume;
 window.setSfxVolume=setSfxVolume;
 
-const KW={P:'Protetor',F:'Furioso'},
-      KW_TIPS={Protetor:'Enquanto houver Protetor ou carta em Defesa do lado do defensor, ataques devem mirá-los.',Furioso:'Pode atacar no turno em que é jogada.'},
+const KW={P:'Protetor',F:'Furioso',A:'Absorver',M:'Mutável'},
+      KW_TIPS={Protetor:'Enquanto houver Protetor ou carta em Defesa do lado do defensor, ataques devem mirá-los.',Furioso:'Pode atacar no turno em que é jogada.',Absorver:'Ao entrar, copia uma palavra-chave de um aliado.',Mutável:'No fim do turno, troca ATK e HP.'},
       BC={D1:'draw1',H2:'heal2',P1:'ping1',BR1:'buffRandom1',BA1:'buffAlliesAtk1',M1:'mana1',SM:'sacMana'},
       BC_NAMES={draw1:'Percepção',heal2:'Cura',ping1:'Golpe',buffRandom1:'Benção',buffAlliesAtk1:'Comando',mana1:'Canalizar',sacMana:'Sacrifício'},
       BC_TIPS={draw1:'Compra 1 carta ao entrar',heal2:'Cura 2 de um aliado ao entrar',ping1:'Causa 1 de dano aleatório ao entrar',buffRandom1:'Concede +1/+1 a um aliado aleatório ao entrar',buffAlliesAtk1:'Aliados ganham +1 ATK',mana1:'Ganha 1 de mana ao entrar',sacMana:'Sacrifica um aliado e ganha mana igual ao custo'};
@@ -56,6 +56,11 @@ vikings:[...buildDeck('vikings'),
   ["Batedor da Aldeia","","Viking",3,2,2,"Entra: dano 1 aleatório","","P1",""],
   ["Ancião do Trigo","","Viking",2,2,3,"Entra: +1/+1 aleatório","","BR1",""],
   ["Patriarca da Fazenda","","Viking",4,5,5,"Aliados +1 ATK","","BA1",""],
+  ["Rastreador do Fiorde","","Viking",1,2,1,"Entra: compre 1","","D1",""],
+  ["Ceifeira Ágil","","Viking",3,2,2,"Furioso","F","",""],
+  ["Defensor do Arado","","Viking",1,5,3,"Protetor","P","",""],
+  ["Runomante Rural","","Viking",2,3,3,"Entra: +1/+1 aleatório","","BR1",""],
+  ["Guerreiro da Foice","","Viking",5,3,4,"Furioso","F","",""],
 ],
 animais:[...buildDeck('animais'),
   ["Lobo Alfa","","Animal",5,4,4,"Furioso","F","",""],
@@ -63,6 +68,12 @@ animais:[...buildDeck('animais'),
   ["Falcão das Montanhas","","Animal",2,3,3,"Entra: compre 1","","D1",""],
   ["Caribu Selvagem","","Animal",4,5,4,"Protetor","P","",""],
   ["Texugo Ártico","","Animal",3,2,2,"Furioso","F","",""],
+  ["Foca do Gelo","","Animal",2,3,2,"Entra: compre 1","","D1",""],
+  ["Lobo Uivante","","Animal",4,3,4,"Furioso","F","",""],
+  ["Raposa Escarlate","","Animal",3,2,2,"Furioso","F","",""],
+  ["Touro das Neves","","Animal",5,5,5,"Protetor","P","",""],
+  ["Corvo Astuto","","Animal",1,2,2,"Entra: compre 1","","D1",""],
+  ["Fera das Cavernas","","Animal",6,6,6,"Furioso","F","",""],
 ],
 pescadores:[...buildDeck('pescadores'),
   ["Curandeiro do Mar","","Viking",1,4,3,"Entra: cura 2","","H2",""],
@@ -70,6 +81,11 @@ pescadores:[...buildDeck('pescadores'),
   ["Caçador de Tesouros","","Viking",2,2,2,"Entra: compre 1","","D1",""],
   ["Escudeiro do Convés","","Viking",2,5,4,"Protetor","P","",""],
   ["Guarda do Cais","","Viking",3,2,3,"Entra: dano 1 aleatório","","P1",""],
+  ["Aprendiz de Rede","","Viking",1,2,1,"Entra: compre 1","","D1",""],
+  ["Baleeiro Leal","","Viking",2,4,3,"Protetor","P","",""],
+  ["Atirador do Convés","","Viking",3,2,2,"Entra: dano 1 aleatório","","P1",""],
+  ["Sacerdote das Ondas","","Viking",2,3,3,"Entra: cura 2","","H2",""],
+  ["Corsário Intrépido","","Viking",4,2,3,"Furioso","F","",""],
 ],
 floresta:[...buildDeck('floresta'),
   ["Lince da Sombra","","Animal",4,2,3,"Furioso","F","",""],
@@ -77,12 +93,40 @@ floresta:[...buildDeck('floresta'),
   ["Guardião Musgoso","","Animal",3,5,4,"Protetor","P","",""],
   ["Cervo Rúnico","","Animal",3,3,3,"Entra: +1/+1 aleatório","","BR1",""],
   ["Javali Voraz","","Animal",5,3,4,"Furioso","F","",""],
+  ["Lebre da Névoa","","Animal",1,1,1,"Veloz","","",""],
+  ["Guardião da Clareira","","Animal",2,5,3,"Protetor","P","",""],
+  ["Raposa Sombria","","Animal",3,2,2,"Furioso","F","",""],
+  ["Urso Musgoso","","Animal",5,6,5,"Protetor","P","",""],
+  ["Coruja Mensageira","","Animal",1,2,2,"Entra: compre 1","","D1",""],
+  ["Cervo das Runas","","Animal",3,3,3,"Entra: +1/+1 aleatório","","BR1",""],
+],
+convergentes:[
+  ["Neófito Convergente","🌀","Convergente",2,2,1,"Entra: copia uma palavra-chave de um aliado","A"],
+  ["Proteiforme da Aurora","🌈","Convergente",3,3,3,"","M"],
+  ["Guardião Quimérico","🛡️🐺","Convergente",2,6,4,"","P|M"],
+  ["Raider Metamorfo","⚔️🌊","Convergente",4,2,3,"","F|M"],
+  ["Runa Voraz","🌀🪨","Convergente",1,4,2,"Ganha +1 ATK sempre que um aliado morre."],
+  ["Totem Absorvente","🪵🌀","Convergente",0,5,3,"Fim de turno: copia uma palavra-chave de um inimigo aleatório.","P"],
+  ["Arauto da Aurora","✨👑","Convergente",5,5,6,"Se você copiou ≥3 palavras-chave na partida, aliados +1/+1."],
+  ["Sombra Rúnica","🌘🌀","Convergente",3,3,3,"Sempre que absorver, ganha +1/+1.","A"],
+  ["Guerreiro Sincrético","⚔️🛡️","Convergente",4,4,4,"Entra: escolha Furioso ou Protetor; ganha essa palavra-chave."],
+  ["Lince Metamórfico","🐱🌈","Convergente",3,2,2,"","F|M"],
+  ["Capataz de Runas","🌀⚙️","Convergente",2,4,3,"Ao absorver, causa 1 de dano a todos os inimigos.","A"],
+  ["Colosso Alquímico","🗿🌈","Convergente",7,7,7,"Entra: copia uma palavra-chave de cada aliado.","M"],
+  ["Essência Convergente","💠","Convergente",0,0,1,"Entra com ATK/HP iguais ao nº de palavras-chave diferentes que você controla.","A"],
+  ["Discípulo Maleável","","Convergente",1,3,2,"","M"],
+  ["Sentinela Vórtice","","Convergente",2,4,3,"Entra: copia uma palavra-chave de um aliado","P|A"],
+  ["Tecelão Cambiante","","Convergente",2,3,3,"Entra: compre 1","A","D1"],
+  ["Eco Mutante","","Convergente",4,4,4,"","A|M"],
+  ["Bruto Assimilador","","Convergente",5,5,5,"","A|M"],
+  ["Sábio Prismal","","Convergente",3,5,4,"Entra: +1/+1 aleatório","M","BR1"],
+  ["Avatar Mutagênico","","Convergente",6,6,6,"","M"],
 ]};
 const ALL_DECKS=Object.keys(TEMPLATES);
 const G={playerHP:30,aiHP:30,turn:0,playerMana:0,playerManaCap:0,aiMana:0,aiManaCap:0,current:'player',playerDeck:[],aiDeck:[],playerHand:[],aiHand:[],playerBoard:[],aiBoard:[],playerDiscard:[],aiDiscard:[],chosen:null,playerDeckChoice:'vikings',aiDeckChoice:rand(ALL_DECKS),customDeck:null};
 const els={pHP:$('#playerHP'),pHP2:$('#playerHP2'),aHP:$('#aiHP'),aHP2:$('#aiHP2'),opponentLabel:$('#opponentLabel'),mana:$('#mana'),pHand:$('#playerHand'),pBoard:$('#playerBoard'),aBoard:$('#aiBoard'),endBtn:$('#endTurnBtn'),muteBtn:$('#muteBtn'),aAva:$('#aiAvatar'),drawCount:$('#drawCount'),discardCount:$('#discardCount'),barPHP:$('#barPlayerHP'),barAHP:$('#barAiHP'),barMana:$('#barMana'),wrap:$('#gameWrap'),start:$('#start'),openEncy:$('#openEncy'),ency:$('#ency'),encyGrid:$('#encyGrid'),encyFilters:$('#encyFilters'),closeEncy:$('#closeEncy'),startGame:$('#startGame'),endOverlay:$('#endOverlay'),endMsg:$('#endMsg'),endSub:$('#endSub'),playAgainBtn:$('#playAgainBtn'),rematchBtn:$('#rematchBtn'),menuBtn:$('#menuBtn'),openMenuBtn:$('#openMenuBtn'),gameMenu:$('#gameMenu'),closeMenuBtn:$('#closeMenuBtn'),resignBtn:$('#resignBtn'),restartBtn:$('#restartBtn'),mainMenuBtn:$('#mainMenuBtn'),turnIndicator:$('#turnIndicator'),emojiBar:$('#emojiBar'),playerEmoji:$('#playerEmoji'),opponentEmoji:$('#opponentEmoji'),deckBuilder:$('#deckBuilder'),saveDeck:$('#saveDeck')};
 els.startGame.disabled=true;
-const DECK_TITLES={vikings:'Fazendeiros Vikings',animais:'Bestas do Norte',pescadores:'Pescadores do Fiorde',floresta:'Feras da Floresta',custom:'Custom'};
+const DECK_TITLES={vikings:'Fazendeiros Vikings',animais:'Bestas do Norte',pescadores:'Pescadores do Fiorde',floresta:'Feras da Floresta',convergentes:'Convergentes da Aurora',custom:'Custom'};
 const DECK_ASSETS={
   vikings:{folder:'farm-vikings',back:'fv',dbExt:'png',cbExt:'webp'},
   pescadores:{folder:'fJord-fishers',back:'jf',dbExt:'webp',cbExt:'webp'},
@@ -140,7 +184,7 @@ function setDeckBacks(){
 // deck builder DOM (may be null if builder UI not present)
 const poolEl=$('#pool'), chosenEl=$('#chosen'), countEl=$('#countDeck'), curveEl=$('#curve');
 // safe builder functions (no-ops if UI not present)
-function renderPool(){const all=[...TEMPLATES.vikings,...TEMPLATES.animais,...TEMPLATES.pescadores,...TEMPLATES.floresta];if(!poolEl)return;poolEl.innerHTML='';all.forEach(raw=>{const name=raw[0]|| (typeof raw[9]==='string'?normalizeCardName(raw[9]):'');const emoji=raw[1]||'';const row=document.createElement('div');row.className='pitem';row.innerHTML=`<span class="c">${raw[5]}</span><div>${emoji} ${name}</div><button class="add">+</button>`;row.querySelector('.add').onclick=()=>{if(!G.customDeck)G.customDeck=[];if(G.customDeck.length>=20)return;const c=makeCard(raw);G.customDeck.push(c);renderChosen();updateCurve()};poolEl.appendChild(row)})}
+function renderPool(){const all=[...TEMPLATES.vikings,...TEMPLATES.animais,...TEMPLATES.pescadores,...TEMPLATES.floresta,...TEMPLATES.convergentes];if(!poolEl)return;poolEl.innerHTML='';all.forEach(raw=>{const name=raw[0]|| (typeof raw[9]==='string'?normalizeCardName(raw[9]):'');const emoji=raw[1]||'';const row=document.createElement('div');row.className='pitem';row.innerHTML=`<span class="c">${raw[5]}</span><div>${emoji} ${name}</div><button class="add">+</button>`;row.querySelector('.add').onclick=()=>{if(!G.customDeck)G.customDeck=[];if(G.customDeck.length>=20)return;const c=makeCard(raw);G.customDeck.push(c);renderChosen();updateCurve()};poolEl.appendChild(row)})}
 function renderChosen(){if(!chosenEl||!countEl)return;chosenEl.innerHTML='';const list=(G.customDeck||[]);list.forEach((c,i)=>{const item=document.createElement('div');item.className='chitem';item.dataset.idx=i;item.innerHTML=`<div>${c.emoji} ${c.name} <small>(${c.cost})</small></div><button class="rm">remover</button>`;item.querySelector('.rm').onclick=()=>{const idx=Number(item.dataset.idx);if(idx>=0){G.customDeck.splice(idx,1);renderChosen();updateCurve()}};chosenEl.appendChild(item)});countEl.textContent=String(list.length)}
 function updateCurve(){if(!curveEl)return;const list=(G.customDeck||[]);const buckets=new Array(8).fill(0);list.forEach(c=>{buckets[Math.min(c.cost,7)]++});curveEl.innerHTML='';const max=Math.max(1,Math.max(...buckets));buckets.forEach(v=>{const bar=document.createElement('div');bar.className='barc';const i=document.createElement('i');i.style.width=(v/max*100)+'%';bar.appendChild(i);curveEl.appendChild(bar)})}
 // --- Global error capture ---
@@ -297,12 +341,16 @@ function showMultiplayerDeckSelect(){
 }
 function showTurnIndicator(){if(!els.turnIndicator)return;els.turnIndicator.textContent=G.current==='player'?'Seu turno':'Turno do oponente'}
 function showEmoji(side,e){const el=side==='player'?els.playerEmoji:els.opponentEmoji;if(!el)return;el.textContent=e;el.classList.add('show');setTimeout(()=>el.classList.remove('show'),1500)}
-function newTurn(skipDraw=false){G.turn++;if(G.current==='player'){if(!skipDraw){if(G.playerDeck.length<=4){G.playerDeck.push(...shuffle(G.playerDiscard.splice(0)))}draw('player',5)}G.playerManaCap=clamp(G.playerManaCap+1,0,10);G.playerMana=G.playerManaCap;G.playerBoard.forEach(c=>c.canAttack=true)}else{if(!skipDraw){if(G.aiDeck.length<=4){G.aiDeck.push(...shuffle(G.aiDiscard.splice(0)))}draw('ai',5)}G.aiManaCap=clamp(G.aiManaCap+1,0,10);G.aiMana=G.aiManaCap;G.aiBoard.forEach(c=>c.canAttack=true)}renderAll();showTurnIndicator()}
-function endTurn(){if(G.current!=='player')return;discardHand('player');G.current='ai';G.chosen=null;updateTargetingUI();newTurn();sfx('end');if(window.isMultiplayer){NET.sendTurn('end')}else{setTimeout(aiTurn,500)}}
+function newTurn(skipDraw=false,prev){if(prev)applyEndTurnEffects(prev);G.turn++;if(G.current==='player'){if(!skipDraw){if(G.playerDeck.length<=4){G.playerDeck.push(...shuffle(G.playerDiscard.splice(0)))}draw('player',5)}G.playerManaCap=clamp(G.playerManaCap+1,0,10);G.playerMana=G.playerManaCap;G.playerBoard.forEach(c=>c.canAttack=true)}else{if(!skipDraw){if(G.aiDeck.length<=4){G.aiDeck.push(...shuffle(G.aiDiscard.splice(0)))}draw('ai',5)}G.aiManaCap=clamp(G.aiManaCap+1,0,10);G.aiMana=G.aiManaCap;G.aiBoard.forEach(c=>c.canAttack=true)}renderAll();showTurnIndicator()}
+function endTurn(){if(G.current!=='player')return;discardHand('player');G.current='ai';G.chosen=null;updateTargetingUI();newTurn(false,'player');sfx('end');if(window.isMultiplayer){NET.sendTurn('end')}else{setTimeout(aiTurn,500)}}
 function playFromHand(id,st){if(G.current!=='player')return;const i=G.playerHand.findIndex(c=>c.id===id);if(i<0)return;const c=G.playerHand[i];if(c.cost>G.playerMana||G.playerBoard.length>=5)return;G.playerHand.splice(i,1);summon('player',c,st);G.playerMana-=c.cost;renderAll();sfx(st==='defense'?'defense':'play')}
-function summon(side,c,st='attack',skipBC=false){const board=side==='player'?G.playerBoard:G.aiBoard;c.stance=st;c.canAttack=(st==='attack')&&c.kw.includes('Furioso');c.summonTurn=G.turn;board.push(c);log(`${side==='player'?'Você':'Inimigo'} jogou ${c.name} em modo ${st==='defense'?'defesa':'ataque'}.`);let effects=[];if(!skipBC){effects=triggerBattlecry(side,c);if(window.isMultiplayer&&side==='player'){NET.sendMove({type:'summon',card:c,stance:st,effects})}}if(st==='defense')setTimeout(()=>animateDefense(c.id),30);return effects}
+function summon(side,c,st='attack',skipBC=false){const board=side==='player'?G.playerBoard:G.aiBoard;c.stance=st;c.canAttack=(st==='attack')&&c.kw.includes('Furioso');c.summonTurn=G.turn;board.push(c);log(`${side==='player'?'Você':'Inimigo'} jogou ${c.name} em modo ${st==='defense'?'defesa':'ataque'}.`);let effects=[];if(!skipBC){effects=triggerBattlecry(side,c);if(window.isMultiplayer&&side==='player'){NET.sendMove({type:'summon',card:c,stance:st,effects})}}if(c.kw.includes('Absorver'))absorbFromAlly(side,c);if(st==='defense')setTimeout(()=>animateDefense(c.id),30);return effects}
 function triggerBattlecry(side,c){const foe=side==='player'?'ai':'player';const effects=[];switch(c.battlecry){case 'draw1':draw(side,1);log(`${c.name}: comprou 1 carta.`);effects.push({type:'draw'});break;case 'heal2':{const allies=(side==='player'?G.playerBoard:G.aiBoard);if(allies.length){const t=rand(allies);t.hp=Math.min(t.hp+2,20);fxTextOnCard(t.id,'+2','heal');const n=nodeById(t.id);if(n){const r=n.getBoundingClientRect();screenParticle('healing',r.left+r.width/2,r.top+r.height/2);}log(`${c.name}: curou 2 em ${t.name}.`);effects.push({type:'heal',targetId:t.id,amount:2})}}break;case 'ping1':{const foes=(foe==='ai'?G.aiBoard:G.playerBoard);if(foes.length){const t=rand(foes);damageMinion(t,1);particleOnCard(t.id,'attack');fxTextOnCard(t.id,'-1','dmg');log(`${c.name}: 1 de dano em ${t.name}.`);checkDeaths();renderAll();sfx('hit');effects.push({type:'damage',targetId:t.id,amount:1})}}break;case 'buffRandom1':{const allies=(side==='player'?G.playerBoard:G.aiBoard).filter(x=>x.id!==c.id);if(allies.length){const t=rand(allies);t.atk+=1;t.hp+=1;fxTextOnCard(t.id,'+1/+1','buff');particleOnCard(t.id,'magic');log(`${c.name}: deu +1/+1 em ${t.name}.`);effects.push({type:'buff',targetId:t.id,atk:1,hp:1})}}break;case 'buffAlliesAtk1':{const allies=(side==='player'?G.playerBoard:G.aiBoard).filter(x=>x.id!==c.id);allies.forEach(x=>{x.atk+=1;fxTextOnCard(x.id,'+1 ATK','buff');particleOnCard(x.id,'magic');effects.push({type:'buff',targetId:x.id,atk:1,hp:0})});if(allies.length)log(`${c.name}: aliados ganharam +1 de ataque.`)}break;case 'mana1':{if(side==='player'){G.playerManaCap=clamp(G.playerManaCap+1,0,10);G.playerMana=Math.min(G.playerMana+1,G.playerManaCap);}else{G.aiManaCap=clamp(G.aiManaCap+1,0,10);G.aiMana=Math.min(G.aiMana+1,G.aiManaCap);}log(`${c.name}: ganhou 1 de mana.`);effects.push({type:'mana',amount:1})}break;case 'sacMana':{const allies=(side==='player'?G.playerBoard:G.aiBoard).filter(x=>x.id!==c.id);if(allies.length){const t=rand(allies);const board=side==='player'?G.playerBoard:G.aiBoard;const discard=side==='player'?G.playerDiscard:G.aiDiscard;const idx=board.findIndex(x=>x.id===t.id);if(idx>-1){board.splice(idx,1);discard.push(t);resetCardState(t);particleOnCard(t.id,'explosion');}if(side==='player'){G.playerMana=Math.min(G.playerMana+t.cost,G.playerManaCap);}else{G.aiMana=Math.min(G.aiMana+t.cost,G.aiManaCap);}fxTextOnCard(t.id,'sac','dmg');log(`${c.name}: sacrificou ${t.name} e ganhou ${t.cost} de mana.`);effects.push({type:'sacMana',targetId:t.id,amount:t.cost});checkDeaths();renderAll();}}break;}return effects}
 function applyBattlecryEffects(side,effects){effects.forEach(e=>{if(e.type==='heal'){const allies=side==='player'?G.playerBoard:G.aiBoard;const t=allies.find(x=>x.id===e.targetId);if(t){t.hp=Math.min(t.hp+e.amount,20);fxTextOnCard(t.id,'+'+e.amount,'heal');particleOnCard(t.id,'healing')}}else if(e.type==='damage'){const foes=side==='player'?G.aiBoard:G.playerBoard;const t=foes.find(x=>x.id===e.targetId);if(t){damageMinion(t,e.amount);particleOnCard(t.id,'attack');fxTextOnCard(t.id,'-'+e.amount,'dmg')}}else if(e.type==='buff'){const allies=side==='player'?G.playerBoard:G.aiBoard;const t=allies.find(x=>x.id===e.targetId);if(t){t.atk+=e.atk;t.hp+=e.hp;fxTextOnCard(t.id,'+'+e.atk+(e.hp?'/'+e.hp:''),'buff');particleOnCard(t.id,'magic')}}else if(e.type==='mana'){if(side==='player'){G.playerManaCap=clamp(G.playerManaCap+e.amount,0,10);G.playerMana=Math.min(G.playerMana+e.amount,G.playerManaCap);}else{G.aiManaCap=clamp(G.aiManaCap+e.amount,0,10);G.aiMana=Math.min(G.aiMana+e.amount,G.aiManaCap);}}else if(e.type==='sacMana'){const allies=side==='player'?G.playerBoard:G.aiBoard;const discard=side==='player'?G.playerDiscard:G.aiDiscard;const t=allies.find(x=>x.id===e.targetId);if(t){allies.splice(allies.indexOf(t),1);discard.push(t);resetCardState(t);particleOnCard(t.id,'explosion');}if(side==='player'){G.playerMana=Math.min(G.playerMana+e.amount,G.playerManaCap);}else{G.aiMana=Math.min(G.aiMana+e.amount,G.aiManaCap);}}});checkDeaths()}
+
+function absorbFromAlly(side,c){const board=side==='player'?G.playerBoard:G.aiBoard;const allies=board.filter(x=>x.id!==c.id&&x.kw&&x.kw.length);if(!allies.length)return;const src=rand(allies);const choices=src.kw.filter(k=>!c.kw.includes(k));if(!choices.length)return;const kw=rand(choices);c.kw.push(kw);particleOnCard(c.id,'magic');fxTextOnCard(c.id,kw,'buff');log(`${c.name} absorveu ${kw}.`);if(c.name==='Sombra Rúnica'){c.atk+=1;c.hp+=1;}if(c.name==='Capataz de Runas'){const foes=side==='player'?G.aiBoard:G.playerBoard;foes.forEach(t=>{damageMinion(t,1);particleOnCard(t.id,'attack');fxTextOnCard(t.id,'-1','dmg')});checkDeaths()}}
+
+function applyEndTurnEffects(side){const board=side==='player'?G.playerBoard:G.aiBoard;const foeBoard=side==='player'?G.aiBoard:G.playerBoard;for(const c of board){if(c.kw.includes('Mutável')){const atk=c.atk;c.atk=c.hp;c.hp=atk;fxTextOnCard(c.id,'⇆','buff');}if(c.name==='Totem Absorvente'){const foes=foeBoard.filter(f=>f.kw&&f.kw.length);if(foes.length){const src=rand(foes);const opts=src.kw.filter(k=>!c.kw.includes(k));if(opts.length){const kw=rand(opts);c.kw.push(kw);particleOnCard(c.id,'magic');fxTextOnCard(c.id,kw,'buff');log(`${c.name} absorveu ${kw} de ${src.name}.`)}}}}}
 function updateTargetingUI(){document.body.classList.toggle('targeting',!!G.chosen)}
 function validateChosen(){
   if(!G.chosen) return false;
@@ -346,7 +394,7 @@ function attackCard(attacker,target){if(!attacker||!attacker.canAttack||attacker
 function attackFace(attacker,face){if(!attacker||!attacker.canAttack||attacker.stance==='defense')return;sfx('attack');const a=nodeById(attacker.id);if(a){const ar=a.getBoundingClientRect();screenSlash(ar.right,ar.top+ar.height/2,10)}animateAttack(attacker.id,null);particleOnFace(face,'attack');const dmg=attacker.atk;attacker.canAttack=false;if(face==='ai'){G.aiHP=clamp(G.aiHP-dmg,0,99);log(`${attacker.name} causou ${dmg} ao Inimigo!`);sfx('crit')}else{G.playerHP=clamp(G.playerHP-dmg,0,99);log(`${attacker.name} causou ${dmg} a Você!`);sfx('hit')}checkWin();if(window.isMultiplayer&&G.current==='player'){NET.sendMove({type:'attackFace',attackerId:attacker.id})}G.chosen=null;updateTargetingUI();els.aBoard.classList.remove('face-can-attack');renderAll()}
 function damageMinion(m,amt){if(!m||typeof amt!=='number')return;m.hp=clamp(m.hp-amt,0,99);if(m.hp<=0) setTimeout(checkDeaths,10)}
 function checkDeaths(){const deadA=G.aiBoard.filter(c=>c.hp<=0);deadA.forEach(c=>{particleOnCard(c.id,'explosion');resetCardState(c);});if(deadA.length){G.aiBoard=G.aiBoard.filter(c=>c.hp>0);G.aiDiscard.push(...deadA);log('Uma criatura inimiga caiu.')}const deadP=G.playerBoard.filter(c=>c.hp<=0);deadP.forEach(c=>{particleOnCard(c.id,'explosion');resetCardState(c);});if(deadP.length){G.playerBoard=G.playerBoard.filter(c=>c.hp>0);G.playerDiscard.push(...deadP);log('Sua criatura caiu.')}els.discardCount.textContent=G.playerDiscard.length}
-function aiTurn(){const skill=G.aiSkill||1;const playable=G.aiHand.filter(c=>c.cost<=G.aiMana);if(skill===2){playable.sort((a,b)=>(b.atk+b.hp)-(a.atk+a.hp))}else if(skill===1){playable.sort((a,b)=>b.cost-a.cost)}else{playable.sort(()=>Math.random()-0.5)}while(playable.length&&G.aiBoard.length<5&&G.aiMana>0){const c=skill===0?playable.pop():playable.shift();const i=G.aiHand.findIndex(x=>x.id===c.id);if(i>-1&&c.cost<=G.aiMana){G.aiHand.splice(i,1);const stance=(c.hp>=c.atk+1)?(Math.random()<.7?'defense':'attack'):(Math.random()<.3?'defense':'attack');summon('ai',c,stance);G.aiMana-=c.cost}}renderAll();const attackers=G.aiBoard.filter(c=>c.canAttack&&c.stance!=='defense');function next(){if(!attackers.length){discardHand('ai');G.current='player';newTurn();return}const a=attackers.shift();const legal=G.playerBoard.filter(x=>legalTarget('player',x));if(legal.length){let target;if(skill===2){target=legal.reduce((p,c)=>c.hp<p.hp?c:p,legal[0])}else{target=rand(legal)}attackCard(a,target)}else{attackFace(a,'player')}setTimeout(next,500)}setTimeout(next,500)}
+function aiTurn(){const skill=G.aiSkill||1;const playable=G.aiHand.filter(c=>c.cost<=G.aiMana);if(skill===2){playable.sort((a,b)=>(b.atk+b.hp)-(a.atk+a.hp))}else if(skill===1){playable.sort((a,b)=>b.cost-a.cost)}else{playable.sort(()=>Math.random()-0.5)}while(playable.length&&G.aiBoard.length<5&&G.aiMana>0){const c=skill===0?playable.pop():playable.shift();const i=G.aiHand.findIndex(x=>x.id===c.id);if(i>-1&&c.cost<=G.aiMana){G.aiHand.splice(i,1);const stance=(c.hp>=c.atk+1)?(Math.random()<.7?'defense':'attack'):(Math.random()<.3?'defense':'attack');summon('ai',c,stance);G.aiMana-=c.cost}}renderAll();const attackers=G.aiBoard.filter(c=>c.canAttack&&c.stance!=='defense');function next(){if(!attackers.length){discardHand('ai');G.current='player';newTurn(false,'ai');return}const a=attackers.shift();const legal=G.playerBoard.filter(x=>legalTarget('player',x));if(legal.length){let target;if(skill===2){target=legal.reduce((p,c)=>c.hp<p.hp?c:p,legal[0])}else{target=rand(legal)}attackCard(a,target)}else{attackFace(a,'player')}setTimeout(next,500)}setTimeout(next,500)}
 function fireworks(win){const b=document.createElement('div');b.className='boom';b.style.left='50%';b.style.top='50%';b.style.background=`radial-gradient(circle at 50% 50%, ${win?'#8bf5a2':'#ff8a8a'}, transparent)`;document.body.appendChild(b);setTimeout(()=>b.remove(),650);} 
 function endGame(win){stopMenuMusic();els.endMsg.textContent=win?'You WIN!':'You Lose...';els.endMsg.style.color=win?'#8bf5a2':'#ff8a8a';els.endSub.textContent=win?'Parabéns! Quer continuar jogando?':'Tentar de novo ou voltar ao menu.';els.endOverlay.classList.add('show');setTimeout(()=>fireworks(win),1000);} 
 function checkWin(){if(G.aiHP<=0){endGame(true)}if(G.playerHP<=0){endGame(false)}}
@@ -404,7 +452,7 @@ els.startGame.addEventListener('click',()=>{if(els.startGame.disabled)return;if(
 els.openEncy.addEventListener('click',()=>renderEncy('all',false));els.closeEncy.addEventListener('click',()=>{els.ency.classList.remove('show')});$$('.filters .fbtn').forEach(b=>b.addEventListener('click',()=>{renderEncy(b.dataset.deck,false)}));
 els.playAgainBtn.addEventListener('click',()=>{if(window.isMultiplayer){showMultiplayerDeckSelect();els.endOverlay.classList.remove('show');}else{els.endOverlay.classList.remove('show');startGame()}});els.rematchBtn.addEventListener('click',()=>{if(window.isMultiplayer&&window.NET){NET.requestRematch();els.rematchBtn.disabled=true;els.endSub.textContent='Aguardando oponente';}else{els.endOverlay.classList.remove('show');startGame()}});els.menuBtn.addEventListener('click',()=>{els.endOverlay.classList.remove('show');els.start.style.display='grid';els.wrap.style.display='none';startMenuMusic('menu');if(window.isMultiplayer&&window.NET){NET.disconnect();}window.isMultiplayer=false;window.mpState=null;const custom=document.querySelector('.deckbtn[data-deck="custom"]');custom&&(custom.style.display='');if(els.startGame){els.startGame.textContent='Jogar';els.startGame.disabled=true;}});
 function handleMove(move){switch(move.type){case 'summon':{summon('ai',move.card,move.stance,true);applyBattlecryEffects('ai',move.effects||[]);G.aiMana-=move.card.cost;renderAll();break}case 'attack':{const a=G.aiBoard.find(x=>x.id===move.attackerId);const t=G.playerBoard.find(x=>x.id===move.targetId);if(a&&t)attackCard(a,t);break}case 'attackFace':{const a=G.aiBoard.find(x=>x.id===move.attackerId);if(a)attackFace(a,'player');break}}}
-function handleTurn(turn){if(turn==='end'){G.current='player';G.chosen=null;updateTargetingUI();newTurn()}}
+function handleTurn(turn){if(turn==='end'){G.current='player';G.chosen=null;updateTargetingUI();newTurn(false,'ai')}}
 if(window.NET){NET.onOpponentDeckConfirmed(d=>{G.aiDeckChoice=d;if(window.mpState==='waitingDeck'){els.startGame.textContent='Iniciar';els.startGame.disabled=false;window.mpState='readyStart'}else{window.opponentConfirmed=true}});NET.onStartGame(()=>{els.start.style.display='none';els.wrap.style.display='block';initAudio();ensureRunning();stopMenuMusic();startGame(NET.isHost()?'player':'ai');window.mpState=null;window.opponentConfirmed=false});NET.onOpponentName(n=>{window.opponentName=n;updateOpponentLabel()})}
 if(window.NET){
 NET.onMove(handleMove);

--- a/server.js
+++ b/server.js
@@ -11,7 +11,7 @@ const io = new Server(server);
 const PORT = process.env.PORT || 3000;
 
 // Decks permitidos no modo multiplayer
-const VALID_DECKS = new Set(['vikings', 'animais', 'pescadores', 'floresta', 'custom']);
+const VALID_DECKS = new Set(['vikings', 'animais', 'pescadores', 'floresta', 'convergentes', 'custom']);
 
 // Informações sobre salas em memória
 const rooms = new Map();


### PR DESCRIPTION
## Summary
- add Absorver and Mutável keywords and logic
- introduce Convergentes da Aurora deck and enable selection
- expand every deck to 20 cards with new units

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ab89bfecd0832ba03c693771d5aeb3