### PR TITLE
Hide custom deck option

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -339,6 +339,7 @@ gap:4px;
 align-items:flex-start;
 justify-content:center;
 overflow:visible}
+.deckbtn[data-deck="custom"]{display:none}
 .deckbtn::before{content:"";
 position:absolute;
 inset:-2px;


### PR DESCRIPTION
## Summary
- hide custom deck option on deck selection screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68abc95207e0832b94585a44455b96ea