### PR TITLE
feat: add story mode scaffolding

### DIFF
--- a/docs/story-mode.md
+++ b/docs/story-mode.md
@@ -1,0 +1,35 @@
+# Modo História Roguelike
+
+Este documento descreve a proposta inicial para o modo História com elementos de roguelike.
+
+## Visão Geral
+
+O modo adiciona progressão em níveis e estrutura de torre. Jogadores escolhem uma facção e enfrentam ondas crescentes de inimigos, com elites e chefes a cada 10 rodadas.
+
+## Totens
+- Nova categoria de cartas.
+- Ao serem jogados, geram um totem abaixo do campo com até três slots de buff.
+- Totens podem fortalecer cartas em campo com efeitos como ataque, defesa ou cura.
+- Limite de três totens ativos simultaneamente.
+
+## Torre de Progressão
+- Inimigos ficam mais fortes a cada rodada.
+- Elites aparecem aleatoriamente, concedendo melhores recompensas.
+- Chefes surgem nos rounds 10, 20, 30...
+- Nível 1 possui um chefe final; níveis posteriores trazem dois chefes.
+
+## Loja
+- A loja aparece em pontos fixos da escalada.
+- Permite comprar cartas, totens e buffs temporários.
+- Itens priorizam cartas da facção escolhida pelo jogador.
+
+## Regras Especiais
+- Mão máxima aumentada para 10 cartas. Excedentes são descartadas com animação de queima.
+- Experiência baseada na dificuldade dos inimigos derrotados.
+- Ao subir de nível, o jogador pode escolher nova carta, evoluir carta existente, obter totem ou ganhar buff permanente.
+
+## Integração
+- O modo História é acessível a partir do menu principal como primeira opção.
+- Modos Solo e Multiplayer permanecem disponíveis.
+
+Este documento é um ponto de partida para futuras implementações do modo.

--- a/js/game/card.js
+++ b/js/game/card.js
@@ -20,6 +20,7 @@ export const CardType = Object.freeze({
   UNIDADE: 'Unidade',
   RITUAL: 'Ritual',
   LENDA_MITICA: 'Lenda Mítica',
+  TOTEM: 'Totem',
 });
 
 export const Faction = Object.freeze({

--- a/js/game/storyMode.js
+++ b/js/game/storyMode.js
@@ -1,0 +1,30 @@
+import { Totem } from './totem.js';
+
+export class StoryMode {
+  constructor({ level = 1 } = {}) {
+    this.level = level;
+    this.round = 0;
+    this.totems = [];
+  }
+
+  nextRound() {
+    this.round += 1;
+    // TODO: escalate difficulty, handle elites and bosses
+  }
+
+  addTotem(totem) {
+    if (this.totems.length >= 3) return false;
+    this.totems.push(totem);
+    return true;
+  }
+
+  reset() {
+    this.round = 0;
+    this.totems = [];
+  }
+}
+
+export function startStory() {
+  // Placeholder entry point for story mode
+  console.log('Story mode started at level 1');
+}

--- a/js/game/totem.js
+++ b/js/game/totem.js
@@ -1,0 +1,19 @@
+export class Totem {
+  constructor({ name = '', slots = 3, buffs = [] } = {}) {
+    this.name = name;
+    this.slots = slots;
+    this.buffs = buffs;
+  }
+
+  canApply() {
+    return this.buffs.length < this.slots;
+  }
+
+  applyBuff(buff) {
+    if (this.canApply()) {
+      this.buffs.push(buff);
+      return true;
+    }
+    return false;
+  }
+}

--- a/js/main.js
+++ b/js/main.js
@@ -1,3 +1,4 @@
 import { startGame } from "./game/index.js";
+import { startStory } from "./game/storyMode.js";
 
-window.FFF = { startGame };
+window.FFF = { startGame, startStory };

--- a/public/index.html
+++ b/public/index.html
@@ -16,6 +16,7 @@
         <img src="img/ui/logos/logo2.png" class="logo-wordmark holo-logo" alt="Farm Fight Formula logo">
       </div>
       <div class="main-actions">
+        <button class="btn" id="menuStory">Modo História</button>
         <button class="btn" id="menuSolo">Jogar Solo</button>
         <button class="btn" id="menuMulti">Jogar Multiplayer</button>
         <button class="btn" id="menuOptions">Opções</button>

--- a/public/js/menu.js
+++ b/public/js/menu.js
@@ -3,6 +3,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const deckScreen = document.getElementById('start');
   const multiMenu = document.getElementById('multiplayerMenu');
   const optionsMenu = document.getElementById('optionsMenu');
+  const storyBtn = document.getElementById('menuStory');
   const soloBtn = document.getElementById('menuSolo');
   const multiBtn = document.getElementById('menuMulti');
   const optBtn = document.getElementById('menuOptions');
@@ -11,6 +12,16 @@ document.addEventListener('DOMContentLoaded', () => {
   const diffLabel = document.querySelector('label[for="difficulty"]');
   const diffSelect = document.getElementById('difficulty');
 
+  if (storyBtn) storyBtn.addEventListener('click', () => {
+    if (titleMenu) titleMenu.style.display = 'none';
+    if (deckScreen) deckScreen.style.display = 'grid';
+    if (diffLabel) diffLabel.style.display = 'none';
+    if (diffSelect) diffSelect.style.display = 'none';
+    const startBtn = document.getElementById('startGame');
+    if (startBtn){startBtn.textContent='Iniciar História';startBtn.disabled=true;}
+    window.currentGameMode = 'story';
+  });
+
   if (soloBtn) soloBtn.addEventListener('click', () => {
     if (titleMenu) titleMenu.style.display = 'none';
     if (deckScreen) deckScreen.style.display = 'grid';
@@ -18,6 +29,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (diffSelect) diffSelect.style.display = '';
     const startBtn = document.getElementById('startGame');
     if (startBtn){startBtn.textContent='Jogar';startBtn.disabled=true;}
+    window.currentGameMode = 'solo';
   });
 
   if (multiBtn) multiBtn.addEventListener('click', () => {
@@ -34,6 +46,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (titleMenu) titleMenu.style.display = 'grid';
     const startBtn = document.getElementById('startGame');
     if (startBtn){startBtn.textContent='Jogar';startBtn.disabled=true;}
+    window.currentGameMode = null;
   });
 
   if (closeOptions) closeOptions.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add Story button to main menu and wire basic navigation
- scaffold roguelike Story mode and totem classes for future gameplay
- document proposed progression and totem mechanics

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68abd3610b2c832bb623352493bba5a6