### PR TITLE
Ajusta HUD e animações de totem

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -29,6 +29,8 @@ body{margin:0;
  position:relative;
  overflow:hidden;
  --safe-bottom:20px;
+ --safe-top:20px;
+ padding-top:var(--safe-top);
  padding-bottom:var(--safe-bottom);
  font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Helvetica,Arial;
  background-image:var(--body-bg),radial-gradient(1200px 700px at 20% 0%,#0e1340 0%,var(--bg) 60%);
@@ -101,6 +103,10 @@ transition:width .25s ease}
 .meter.enemy{min-width:280px}
 
 .meter.enemy .bar{min-width:140px}
+
+.meter.player{min-width:280px}
+
+.meter.player .bar{min-width:140px}
 .center-hud{display:flex;
 gap:8px;
 align-items:center}
@@ -121,7 +127,7 @@ margin:6px 0 2px}
  overflow:visible;
  margin:12px 0;
 width:calc(5*var(--card-w) + 4*14px + 24px)}
-#aiBoard,#playerBoard{margin:0 auto}
+#aiBoard,#playerBoard{margin:0}
 .row{display:flex;gap:14px;align-items:center;flex:1;justify-content:center}
 .row .board{flex:0 0 auto}
 .totem-bar{display:flex;justify-content:center;gap:8px;margin-top:8px}
@@ -306,7 +312,7 @@ transform:translate(-50%,-10px) scale(.9)}
 transform:translate(-50%,-70px) scale(1)}
 }
 
-.enemy-img{display:inline-grid;
+.enemy-img,.player-img{display:inline-grid;
 place-items:center;
 width:28px;
 height:28px;

--- a/public/index.html
+++ b/public/index.html
@@ -125,7 +125,7 @@
   <div class="" id="gameWrap" style="display:none">
     <div class="mid-mana" id="midMana"></div>
     <div class="hud">
-      <div class="meter"><b>Seu HP</b><span class="value" id="playerHP">30</span><div class="bar"><div class="fill" id="barPlayerHP"></div></div></div>
+      <div class="meter player"><b>Seu HP</b><span class="value" id="playerHP">30</span><div class="player-img" id="playerAvatar">👤</div><div class="bar"><div class="fill" id="barPlayerHP"></div></div></div>
       <div class="center-hud"><div class="meter mana"><b>Mana</b><span class="value" id="mana">0/0</span><div class="bar"><div class="fill" id="barMana"></div></div></div><button class="btn-ghost" id="muteBtn" title="Som">🔊 Som</button><button class="btn-ghost" id="openMenuBtn" title="Menu">☰ Menu</button></div>
       <div class="meter enemy" style="justify-self:end"><b>HP Inimigo</b><span class="opp-label" id="opponentLabel"></span><span class="value" id="aiHP">30</span><div class="enemy-img" id="aiAvatar">🧿</div><div class="bar"><div class="fill" id="barAiHP"></div></div></div>
     </div>

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -177,7 +177,7 @@ function updateCardSize(){
   const marginY=e=>{if(!e)return 0;const st=getComputedStyle(e);return parseFloat(st.marginTop)+parseFloat(st.marginBottom)};
   const outer=e=>e?e.offsetHeight+marginY(e):0;
   const pad=(()=>{const st=getComputedStyle(wrap);return parseFloat(st.paddingTop)+parseFloat(st.paddingBottom)})();
-  const bodyPad=(()=>{try{const st=getComputedStyle(document.body);return (parseFloat(st.paddingBottom)||0)+(parseFloat(st.marginBottom)||0);}catch(_){return 0}})();
+  const bodyPad=(()=>{try{const st=getComputedStyle(document.body);return (parseFloat(st.paddingBottom)||0)+(parseFloat(st.marginBottom)||0)+(parseFloat(st.paddingTop)||0)+(parseFloat(st.marginTop)||0);}catch(_){return 0}})();
   const h1=q('h1'),hud=q('.hud'),turn=q('.turn-bar'),totem=q('.totem-bar'),footer=q('.footer'),hand=q('.hand'),board=q('.board');
   const space=outer(h1)+outer(hud)+outer(turn)+outer(totem)+outer(footer)+pad+marginY(hand)+marginY(board)*2+60+bodyPad+24;
   let cardH=(vh-space)/3; if(!isFinite(cardH)||cardH<40) cardH=40; const cardW=cardH*(220/300);
@@ -315,6 +315,7 @@ function describeTotem(card){
   return 'Ative: Bônus a aliados';
 }
 function totemIcon(t){
+  if(t && t.icon) return t.icon;
   const a = t && t.buffs && t.buffs.atk ? 1 : 0;
   const h = t && t.buffs && t.buffs.hp ? 1 : 0;
   if(a && h) return '⚡';
@@ -1149,15 +1150,7 @@ function playFromHand(id,st){
   if(isT){
     if(G.totems.length>=3){ log('Número máximo de Totens atingido.'); return; }
     const node = document.querySelector(`#playerHand .card[data-id='${c.id}']`) || document.querySelector('#playerHand .card:last-child');
-    const doConfirm=(anchor)=>{
-      G.playerHand.splice(i,1); G.playerMana-=c.cost;
-      const t={name:c.name,buffs:c.buffs||{atk:1,hp:1}}; t.icon = totemIcon(t); t.desc = describeTotem(c);
-      try{ if(!window.animationsDisabled){ if(anchor){ const r=anchor.getBoundingClientRect(); const ghost=anchor.cloneNode(true); Object.assign(ghost.style,{position:'fixed',left:r.left+'px',top:r.top+'px',width:r.width+'px',height:r.height+'px',zIndex:1500,transition:'transform .35s ease,opacity .35s ease',transform:'scale(1)',opacity:'1'}); ghost.classList.add('disintegrate'); document.body.appendChild(ghost); setTimeout(()=>{ghost.style.transform='scale(.85) rotate(-2deg)';ghost.style.opacity='0';},10); setTimeout(()=>{try{ghost.remove()}catch(_){ }},420);} const bar=document.getElementById('totemBar');const slots=bar?Array.from(bar.children):[];const idx=G.totems.length;const slot=slots[idx]; if(slot){ const sr=slot.getBoundingClientRect(); const fly=document.createElement('div'); fly.className='totem-fly'; fly.textContent=t.icon||'🗿'; Object.assign(fly.style,{left:(anchor?anchor.getBoundingClientRect().left:sr.left)+'px',top:(anchor?anchor.getBoundingClientRect().top:sr.top)+'px'}); document.body.appendChild(fly); requestAnimationFrame(()=>{fly.style.transform=`translate(${(sr.left+sr.width/2)-(fly.getBoundingClientRect().left)}px, ${(sr.top+sr.height/2)-(fly.getBoundingClientRect().top)}px) scale(0.7)`; fly.style.opacity='1';}); setTimeout(()=>{try{fly.remove()}catch(_){ }},420);} } }catch(_){ }
-      G.totems.push(t);
-      applyTotemBuffsWithFx(t);
-      log(`${c.name} ativado.`);
-      renderAll();
-    };
+    const doConfirm = (anchor)=>{ activateTotemById(c.id, anchor); };
     openTotemConfirm(node||document.body, doConfirm, ()=>{});
     return;
   }
@@ -1188,7 +1181,7 @@ window._activateTotemByIdImpl = function(cardId, anchor){
   const c = G.playerHand[i];
   if(G.totems.length>=3){ log('Número máximo de Totens atingido.'); return; }
   G.playerHand.splice(i,1); G.playerMana-=c.cost;
-  const t={name:c.name,buffs:c.buffs||{atk:1,hp:1}}; t.icon = totemIcon(t); t.desc = describeTotem(c);
+  const t={name:c.name,buffs:c.buffs||{atk:1,hp:1},icon:c.icon}; t.icon = totemIcon(t); t.desc = describeTotem(c);
   try{ if(!window.animationsDisabled && anchor){
     const r=anchor.getBoundingClientRect();
     Object.assign(anchor.style,{position:'fixed',left:r.left+'px',top:r.top+'px',width:r.width+'px',height:r.height+'px',zIndex:1500,margin:'0'});
@@ -1214,7 +1207,7 @@ function activateTotemById(cardId, anchor){
   const c = G.playerHand[i];
   if(G.totems.length>=3){ log('Número máximo de Totens atingido.'); return; }
   G.playerHand.splice(i,1); G.playerMana-=c.cost;
-  const t={name:c.name,buffs:c.buffs||{atk:1,hp:1}}; t.icon = totemIcon(t); t.desc = describeTotem(c);
+  const t={name:c.name,buffs:c.buffs||{atk:1,hp:1},icon:c.icon}; t.icon = totemIcon(t); t.desc = describeTotem(c);
   try{ if(!window.animationsDisabled && anchor){
     const r=anchor.getBoundingClientRect();
     Object.assign(anchor.style,{position:'fixed',left:r.left+'px',top:r.top+'px',width:r.width+'px',height:r.height+'px',zIndex:1500,margin:'0'});


### PR DESCRIPTION
## Summary
- Alinha deck e descarte junto aos tabuleiros
- Equipara barra de HP do jogador à do inimigo e adiciona avatar
- Garante mesmo ícone entre carta de totem e slot, com animação de encaixe

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b24421da04832bb62c8f6d246fa44d