### PR TITLE
Improve shop UI and logic

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -787,6 +787,7 @@ display:block}
 .price-btn{display:inline-flex;align-items:center;justify-content:center;gap:6px;font-weight:700;margin-top:6px;padding:6px 10px;border-radius:10px}
 .coin-icon{width:16px;height:16px}
 .shop-placeholder{width:100%;height:auto;aspect-ratio:calc(var(--card-w) / (var(--card-w) * 1.42));min-height:calc(var(--card-w)*1.42);border:1px dashed #334;border-radius:4px;display:flex;align-items:center;justify-content:center;padding:6px;text-align:center}
+.shop-msg{min-height:1.5em;color:#f87171;text-align:center;font-weight:700}
 .shop-keeper{width:80px;height:80px;border-radius:8px;object-fit:cover}
 /* encounter banner should not block clicks when hidden */
 #encounterBanner{position:fixed;top:50%;left:50%;transform:translate(-50%,-50%) scale(.8);background:#0e2024;border:2px solid #2dd4bf;padding:12px 24px;border-radius:12px;font-weight:900;font-size:32px;color:#e6fffb;text-shadow:0 0 8px #2dd4bf;z-index:3000;opacity:0;transition:transform .4s ease,opacity .4s ease;pointer-events:none}

--- a/public/index.html
+++ b/public/index.html
@@ -194,6 +194,7 @@
   <span style="margin-left:auto"><img src="img/ui/coin.png" class="coin-icon" alt="moeda"> <b id="shopGold">0</b></span>
         <button class="btn" id="btnReroll">Re-rolar</button>
       </div>
+      <div id="shopMsg" class="shop-msg" aria-live="polite"></div>
       <div class="shop-grid" id="shopChoices"></div>
       <div style="margin-top:12px;text-align:right">
         <button id="closeShop" class="btn">Fechar</button>


### PR DESCRIPTION
## Summary
- add in-modal notification area and styling for shop messages
- track purchased items and show inline errors instead of alerts
- simplify shop modal event handling with a single close listener

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b253b0d510832bbd18dfab2f2c8f29