### PR TITLE
feat: track shop purchases via server

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -973,7 +973,13 @@ function checkWin(){
         openShop({
           faction:G.playerDeckChoice,
           gold:G.story.gold,
-          onClose:state=>{G.story.gold=state.gold;proceed();}
+          onClose: async state => {
+            if(state.pending && state.pending.length){
+              try { await Promise.all(state.pending); } catch(_){ }
+            }
+            G.story.gold = state.gold;
+            proceed();
+          }
         });
       }else{
         proceed();

--- a/public/js/shop.js
+++ b/public/js/shop.js
@@ -24,7 +24,20 @@ const NEUTRAL = [
   { name: 'Totem do Carvalho', type: 'totem', desc: '+1 HP', cost: 9 }
 ];
 
-let shopState = { faction: '', gold: 0, onClose: null, unlimited: false, purchased: [] };
+const PLAYER_ID = (() => {
+  try {
+    let id = localStorage.getItem('playerId');
+    if (!id) {
+      id = Math.random().toString(36).slice(2);
+      localStorage.setItem('playerId', id);
+    }
+    return id;
+  } catch (_) {
+    return 'anon';
+  }
+})();
+
+let shopState = { faction: '', gold: 0, onClose: null, unlimited: false, purchased: [], pending: [] };
 let rerolled = false;
 
 function showShopMsg(msg){
@@ -93,11 +106,35 @@ function renderShop(){
   btn.innerHTML = `${it.cost}<img src="img/ui/coin.png" class="coin-icon" alt="moeda">`;
     btn.onclick = () => {
       if(shopState.gold < it.cost){ showShopMsg('Sem ouro.'); return; }
-      shopState.gold -= it.cost;
-      $('#shopGold').textContent = shopState.gold;
       btn.disabled = true;
-      btn.textContent = '✔';
-      shopState.purchased.push(it);
+      const currentGold = shopState.gold;
+      const req = fetch('/api/purchase', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          playerId: PLAYER_ID,
+          itemId: slug(it.name),
+          cost: it.cost,
+          gold: currentGold,
+        })
+      })
+      .then(r => r.json())
+      .then(data => {
+        if(data && typeof data.gold === 'number'){
+          shopState.gold = data.gold;
+          $('#shopGold').textContent = shopState.gold;
+          btn.textContent = '✔';
+          shopState.purchased.push(it);
+        } else {
+          throw new Error('Resposta inválida');
+        }
+      })
+      .catch(err => {
+        console.error('purchase error', err);
+        showShopMsg('Erro ao registrar compra');
+        btn.disabled = false;
+      });
+      shopState.pending.push(req);
     };
     card.appendChild(btn);
     wrap.appendChild(card);
@@ -111,6 +148,7 @@ function openShop({ faction, gold, onClose, unlimited=false }){
   shopState.onClose = onClose;
   shopState.unlimited = unlimited;
   shopState.purchased = [];
+  shopState.pending = [];
   rerolled = false;
   $('#btnReroll').disabled = false;
   $('#shopGold').textContent = shopState.gold;

--- a/server.js
+++ b/server.js
@@ -16,7 +16,27 @@ const VALID_DECKS = new Set(['vikings', 'animais', 'pescadores', 'floresta', 'co
 // Informações sobre salas em memória
 const rooms = new Map();
 
+// Informações de jogadores (ex.: saldo de ouro) em memória
+const players = new Map();
+
+app.use(express.json());
+
 app.use(express.static(path.join(__dirname, 'public')));
+
+// Endpoint simples para registrar compras da loja
+app.post('/api/purchase', (req, res) => {
+  const { playerId, itemId, cost, gold } = req.body || {};
+  if (!playerId || !itemId || typeof cost !== 'number') {
+    return res.status(400).json({ error: 'Dados inválidos' });
+  }
+  // Usa o ouro informado caso seja a primeira interação do jogador
+  const currentGold = players.has(playerId)
+    ? players.get(playerId)
+    : typeof gold === 'number' ? gold : 0;
+  const newGold = currentGold - cost;
+  players.set(playerId, newGold);
+  res.json({ gold: newGold });
+});
 
 
 io.on('connection', (socket) => {


### PR DESCRIPTION
## Summary
- add simple REST endpoint to register shop purchases and track player gold
- send purchase data from shop UI and wait for completion before closing
- ensure game waits for server responses before resuming play after shop

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b275606c24832bad9e80ccc1d5136a