### PR TITLE
Add reroll cost scaling and gold deduction

### DIFF
--- a/public/js/shop.js
+++ b/public/js/shop.js
@@ -25,7 +25,7 @@ const NEUTRAL = [
 ];
 
 let shopState = { faction: '', gold: 0, onClose: null, unlimited: false, purchased: [] };
-let rerolled = false;
+let rerollCount = 0;
 
 function showShopMsg(msg){
   const el = $('#shopMsg');
@@ -104,6 +104,25 @@ function renderShop(){
   });
 }
 
+function updateRerollBtn(){
+  const btn = document.getElementById('btnReroll');
+  if(!btn) return;
+  const cost = 5 * (rerollCount + 1);
+  if(!shopState.unlimited){
+    const remaining = Math.max(0, 1 - rerollCount);
+    if(remaining <= 0){
+      btn.disabled = true;
+      btn.innerHTML = 'Re-rolar (0 restantes)';
+      return;
+    }
+    btn.disabled = false;
+    btn.innerHTML = `Re-rolar (${cost}<img src="img/ui/coin.png" class="coin-icon" alt="moeda">, ${remaining} restantes)`;
+  }else{
+    btn.disabled = false;
+    btn.innerHTML = `Re-rolar (${cost}<img src="img/ui/coin.png" class="coin-icon" alt="moeda">)`;
+  }
+}
+
 function openShop({ faction, gold, onClose, unlimited=false }){
   const map = { vikings:'Furioso', animais:'Furioso', pescadores:'Sombras', floresta:'Percepcao', convergentes:'Percepcao' };
   shopState.faction = map[faction] || faction || 'Furioso';
@@ -111,8 +130,8 @@ function openShop({ faction, gold, onClose, unlimited=false }){
   shopState.onClose = onClose;
   shopState.unlimited = unlimited;
   shopState.purchased = [];
-  rerolled = false;
-  $('#btnReroll').disabled = false;
+  rerollCount = 0;
+  updateRerollBtn();
   $('#shopGold').textContent = shopState.gold;
   $('#shopMsg').textContent = '';
   renderShop();
@@ -146,9 +165,13 @@ shopModal?.addEventListener('click', ev => {
 });
 
 document.getElementById('btnReroll')?.addEventListener('click', () => {
-  if(!shopState.unlimited && rerolled){ showShopMsg('Sem re-rolagens.'); return; }
-  rerolled = true;
-  if(!shopState.unlimited) document.getElementById('btnReroll').disabled = true;
+  const cost = 5 * (rerollCount + 1);
+  if(!shopState.unlimited && rerollCount >= 1){ showShopMsg('Sem re-rolagens.'); return; }
+  if(shopState.gold < cost){ showShopMsg('Sem ouro.'); return; }
+  shopState.gold -= cost;
+  $('#shopGold').textContent = shopState.gold;
+  rerollCount++;
   renderShop();
+  updateRerollBtn();
 });
 document.getElementById('closeShop')?.addEventListener('click', closeShop);


### PR DESCRIPTION
## Summary
- track number of shop rerolls and increase cost for each reroll
- deduct reroll cost from player gold and update button with cost/remaining rerolls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b2756dd418832bbe102836e6df913a