### PR TITLE
fix: close test modal before opening shop

### DIFF
--- a/public/js/menu.js
+++ b/public/js/menu.js
@@ -67,11 +67,12 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   if (testShopBtn) testShopBtn.addEventListener('click', () => {
+    if (testModal) testModal.classList.remove('show');
     if (window.openShop) openShop({ faction: 'random', gold: 30, unlimited: true });
   });
 
   if (testTotemBtn) testTotemBtn.addEventListener('click', () => {
-    if (testModal) testModal.style.display = 'none';
+    if (testModal) testModal.classList.remove('show');
     if (window.startTotemTest) startTotemTest();
   });
 


### PR DESCRIPTION
## Summary
- close the test menu before opening the shop so it appears
- ensure totem test button also hides the test menu

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b28010a4e0832b89daac4e0a209582