### PR TITLE
fix: ensure test menu opens shop

### DIFF
--- a/public/js/menu.js
+++ b/public/js/menu.js
@@ -67,11 +67,18 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   if (testShopBtn) testShopBtn.addEventListener('click', () => {
-    if (window.openShop) openShop({ faction: 'random', gold: 30, unlimited: true });
+    if (testModal){
+      testModal.classList.remove('show');
+      testModal.style.display = 'none';
+    }
+    if (window.openShop) window.openShop({ faction: 'random', gold: 30, unlimited: true });
   });
 
   if (testTotemBtn) testTotemBtn.addEventListener('click', () => {
-    if (testModal) testModal.style.display = 'none';
+    if (testModal){
+      testModal.classList.remove('show');
+      testModal.style.display = 'none';
+    }
     if (window.startTotemTest) startTotemTest();
   });
 

--- a/public/js/shop.js
+++ b/public/js/shop.js
@@ -114,8 +114,8 @@ function genShopOffers(){
     return withImg(base);
   });
   // add a consumable if there's room
-  if(mapped.length < maxOffers) mapped.push(withImg({ name: 'Elixir de Força', type: 'buff', desc: '+1 ATK a suas unidades neste round', cost: 7 }));
-  return mapped.slice(0, maxOffers);
+  if(offers.length < maxOffers) offers.push(withImg({ name: 'Elixir de Força', type: 'buff', desc: '+1 ATK a suas unidades neste round', cost: 7 }));
+  return offers.slice(0, maxOffers);
 }
 
 function renderShop(){
@@ -213,9 +213,9 @@ function openShop({ faction, gold, onClose, unlimited=false }){
   shopState.faction = map[faction] || faction || 'Furioso';
   shopState.gold = gold;
   shopState.onClose = onClose;
-  shopState.onPurchase = onPurchase;
   shopState.unlimited = unlimited;
   shopState.purchased = [];
+  shopState.pending = [];
   rerollCount = 0;
   updateRerollBtn();
   $('#shopGold').textContent = shopState.gold;
@@ -226,6 +226,7 @@ function openShop({ faction, gold, onClose, unlimited=false }){
   if(closeBtn){ closeBtn.disabled = false; }
   const modal = document.getElementById('shopModal');
   if(modal){
+    modal.classList.add('show');
     modal.style.display = 'grid';
   }
 }


### PR DESCRIPTION
## Summary
- hide test modal before invoking shop or totem tests
- show shop modal reliably when opened from menu

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b28010a4e0832b89daac4e0a209582