### PR TITLE
Play death sound effect on unit deaths

### DIFF
--- a/js/game/index.js
+++ b/js/game/index.js
@@ -1529,6 +1529,7 @@ function checkDeaths() {
   const deadA = G.aiBoard.filter((c) => c.hp <= 0);
   deadA.forEach((c) => {
     particleOnCard(c.id, "explosion");
+    sfx("death");
     resetCardState(c);
   });
   if (deadA.length) {
@@ -1539,6 +1540,7 @@ function checkDeaths() {
   const deadP = G.playerBoard.filter((c) => c.hp <= 0);
   deadP.forEach((c) => {
     particleOnCard(c.id, "explosion");
+    sfx("death");
     resetCardState(c);
   });
   if (deadP.length) {


### PR DESCRIPTION
## Summary
- add `sfx("death")` when creatures die to trigger a death audio cue

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b66f4a0f18832b855e2fedf975f6de