### PR TITLE
Add draw card audio cue and particle effect

### DIFF
--- a/js/audio/index.js
+++ b/js/audio/index.js
@@ -44,6 +44,10 @@ export function sfx(n) {
         tone(420, 0.07, "sine", 0.7, 0);
         tone(560, 0.08, "sine", 0.6, 0.06);
       },
+      draw: () => {
+        tone(660, 0.06, "square", 0.6, 0);
+        tone(880, 0.08, "triangle", 0.5, 0.04);
+      },
       defense: () => {
         tone(280, 0.09, "square", 0.6, 0);
         tone(200, 0.12, "sine", 0.5, 0.08);

--- a/js/game/index.js
+++ b/js/game/index.js
@@ -1079,6 +1079,14 @@ function draw(who, n = 1) {
         burnCard(c);
       } else {
         hand.push(c);
+        if (who === "player") {
+          sfx("draw");
+          const deckEl = document.getElementById("drawPile");
+          if (deckEl) {
+            const r = deckEl.getBoundingClientRect();
+            screenParticle("magic", r.left + r.width / 2, r.top + r.height / 2);
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- add "draw" sound effect to audio library
- play draw sound and particle when player draws a card

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b66f47a37c832bbed2adec04fa474d