### PR TITLE
Preserve volume when toggling mute

### DIFF
--- a/js/audio/index.js
+++ b/js/audio/index.js
@@ -1,7 +1,9 @@
 const AudioCtx = window.AudioContext || window.webkitAudioContext;
 let actx = null,
   master = null,
-  muted = false;
+  muted = false,
+  currentMaster = 0.18,
+  currentMusic = 0.18;
 export function initAudio() {
   if (!AudioCtx) return;
   if (!actx) {
@@ -289,7 +291,18 @@ export function tryStartMenuMusicImmediate() {
 
 export function toggleMute(btn) {
   muted = !muted;
-  if (master) master.gain.value = muted ? 0 : 0.18;
-  if (musicGain) musicGain.gain.value = muted ? 0 : 0.18;
+  if (muted) {
+    if (master) {
+      currentMaster = master.gain.value;
+      master.gain.value = 0;
+    }
+    if (musicGain) {
+      currentMusic = musicGain.gain.value;
+      musicGain.gain.value = 0;
+    }
+  } else {
+    if (master) master.gain.value = currentMaster;
+    if (musicGain) musicGain.gain.value = currentMusic;
+  }
   if (btn) btn.textContent = muted ? "🔇 Mudo" : "🔊 Som";
 }


### PR DESCRIPTION
## Summary
- Store current master and music volume values
- Restore saved volumes when unmuting instead of fixed 0.18

## Testing
- `npm test`
- Manual: simulate volume change, mute and unmute to verify persistence


------
https://chatgpt.com/codex/tasks/task_b_68b6e9b26630832b993be9147470646d