### PR TITLE
Add commander slots and rendering

### DIFF
--- a/js/game/index.js
+++ b/js/game/index.js
@@ -566,6 +566,8 @@ const G = {
   aiBoard: [],
   playerDiscard: [],
   aiDiscard: [],
+  playerCommander: null,
+  aiCommander: null,
   chosen: null,
   playerDeckChoice: "vikings",
   aiDeckChoice: rand(ALL_DECKS),
@@ -607,6 +609,8 @@ const els = {
   rematchBtn: $("#rematchBtn"),
   menuBtn: $("#menuBtn"),
   totemBar: $("#totemBar"),
+  playerCommander: $("#playerCommander"),
+  aiCommander: $("#aiCommander"),
 };
 // deck builder DOM (may be null if builder UI not present)
 const poolEl = $("#pool"),
@@ -777,6 +781,7 @@ function renderAll() {
   updateMeters();
   renderHand();
   renderBoard();
+  renderCommanders();
   renderTotems();
 }
 function renderHand() {
@@ -845,6 +850,22 @@ function renderTotems() {
     slot.className = "totem-slot";
     if (G.totems[i]) slot.textContent = "🗿";
     els.totemBar.appendChild(slot);
+  }
+}
+function renderCommanders() {
+  if (els.playerCommander) {
+    els.playerCommander.innerHTML = "";
+    if (G.playerCommander) {
+      const d = cardNode(G.playerCommander, "player");
+      els.playerCommander.appendChild(d);
+    }
+  }
+  if (els.aiCommander) {
+    els.aiCommander.innerHTML = "";
+    if (G.aiCommander) {
+      const d = cardNode(G.aiCommander, "ai");
+      els.aiCommander.appendChild(d);
+    }
   }
 }
 function renderBoard() {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -470,6 +470,12 @@ white-space:nowrap}
  border-radius:18px;
  position:relative;
  flex:0 0 var(--card-w)}
+.commander{display:grid;
+ place-items:center;
+ width:var(--card-w);
+ height:var(--card-h);
+ flex:0 0 var(--card-w);
+ position:relative}
 .pile img{
  display:block;
  width:100%;

--- a/public/index.html
+++ b/public/index.html
@@ -130,15 +130,17 @@
       <div class="meter enemy" style="justify-self:end"><b>HP Inimigo</b><span class="opp-label" id="opponentLabel"></span><span class="value" id="aiHP">30</span><div class="enemy-img" id="aiAvatar">🧿</div><div class="bar"><div class="fill" id="barAiHP"></div></div></div>
     </div>
     <div class="row enemy-row">
-  <div class="pile" id="aiDrawPile"><img src="img/decks/fJord-fishers/deck-backs/jf-db-default.webp" alt="deck"><div class="pile-label">DECK</div></div>
+      <div id="aiCommander" class="commander"></div>
+      <div class="pile" id="aiDrawPile"><img src="img/decks/fJord-fishers/deck-backs/jf-db-default.webp" alt="deck"><div class="pile-label">DECK</div></div>
       <div class="board" id="aiBoard"></div>
-  <div class="pile" id="aiDiscardPile"><img src="img/decks/fJord-fishers/deck-backs/jf-db-default.webp" alt="discard"><div class="pile-label">DESCARTE</div></div>
+      <div class="pile" id="aiDiscardPile"><img src="img/decks/fJord-fishers/deck-backs/jf-db-default.webp" alt="discard"><div class="pile-label">DESCARTE</div></div>
     </div>
     <div class="turn-bar"><div class="turn-indicator" id="turnIndicator"></div><button class="btn" id="endTurnBtn">Encerrar turno</button></div>
     <div class="row">
-  <div class="pile" id="drawPile"><img src="img/decks/fJord-fishers/deck-backs/jf-db-default.webp" alt="deck"><div class="count" id="drawCount">0</div><div class="pile-label">SEU DECK</div></div>
+      <div id="playerCommander" class="commander"></div>
+      <div class="pile" id="drawPile"><img src="img/decks/fJord-fishers/deck-backs/jf-db-default.webp" alt="deck"><div class="count" id="drawCount">0</div><div class="pile-label">SEU DECK</div></div>
       <div class="board" id="playerBoard"></div>
-  <div class="pile" id="discardPile"><img src="img/decks/fJord-fishers/deck-backs/jf-db-default.webp" alt="discard"><div class="count" id="discardCount">0</div><div class="pile-label">DESCARTE</div></div>
+      <div class="pile" id="discardPile"><img src="img/decks/fJord-fishers/deck-backs/jf-db-default.webp" alt="discard"><div class="count" id="discardCount">0</div><div class="pile-label">DESCARTE</div></div>
       <div class="log-wrap"><div class="zone-title">Registro</div><div class="log" id="log"></div></div>
     </div>
     <div class="totem-bar" id="totemBar"></div>

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -162,10 +162,10 @@ class StoryMode{
   reset(){this.round=0;this.totems=[];this.deck=[];this.xp=0;this.gold=30;this.currentEncounter='normal';}
 }
 const ALL_DECKS=Object.keys(TEMPLATES);
-const G={playerHP:30,aiHP:30,turn:0,playerMana:0,playerManaCap:0,aiMana:0,aiManaCap:0,current:'player',playerDeck:[],aiDeck:[],playerHand:[],aiHand:[],playerBoard:[],aiBoard:[],playerDiscard:[],aiDiscard:[],chosen:null,playerDeckChoice:'vikings',aiDeckChoice:rand(ALL_DECKS),customDeck:null,mode:'solo',story:null,enemyScaling:0,maxHandSize:5,totems:[]};
+const G={playerHP:30,aiHP:30,turn:0,playerMana:0,playerManaCap:0,aiMana:0,aiManaCap:0,current:'player',playerDeck:[],aiDeck:[],playerHand:[],aiHand:[],playerBoard:[],aiBoard:[],playerDiscard:[],aiDiscard:[],playerCommander:null,aiCommander:null,chosen:null,playerDeckChoice:'vikings',aiDeckChoice:rand(ALL_DECKS),customDeck:null,mode:'solo',story:null,enemyScaling:0,maxHandSize:5,totems:[]};
 // expose for helpers that run outside this closure
 try{ window.G = G; }catch(_){ }
-const els={pHP:$('#playerHP'),pHP2:$('#playerHP2'),aHP:$('#aiHP'),aHP2:$('#aiHP2'),opponentLabel:$('#opponentLabel'),mana:$('#mana'),pHand:$('#playerHand'),pBoard:$('#playerBoard'),aBoard:$('#aiBoard'),endBtn:$('#endTurnBtn'),muteBtn:$('#muteBtn'),aAva:$('#aiAvatar'),drawCount:$('#drawCount'),discardCount:$('#discardCount'),barPHP:$('#barPlayerHP'),barAHP:$('#barAiHP'),barMana:$('#barMana'),wrap:$('#gameWrap'),start:$('#start'),openEncy:$('#openEncy'),ency:$('#ency'),encyGrid:$('#encyGrid'),encyFilters:$('#encyFilters'),closeEncy:$('#closeEncy'),startGame:$('#startGame'),endOverlay:$('#endOverlay'),endMsg:$('#endMsg'),endSub:$('#endSub'),playAgainBtn:$('#playAgainBtn'),rematchBtn:$('#rematchBtn'),menuBtn:$('#menuBtn'),openMenuBtn:$('#openMenuBtn'),gameMenu:$('#gameMenu'),closeMenuBtn:$('#closeMenuBtn'),resignBtn:$('#resignBtn'),restartBtn:$('#restartBtn'),mainMenuBtn:$('#mainMenuBtn'),turnIndicator:$('#turnIndicator'),emojiBar:$('#emojiBar'),playerEmoji:$('#playerEmoji'),opponentEmoji:$('#opponentEmoji'),deckBuilder:$('#deckBuilder'),saveDeck:$('#saveDeck'),midMana:$('#midMana')};
+const els={pHP:$('#playerHP'),pHP2:$('#playerHP2'),aHP:$('#aiHP'),aHP2:$('#aiHP2'),opponentLabel:$('#opponentLabel'),mana:$('#mana'),pHand:$('#playerHand'),pBoard:$('#playerBoard'),aBoard:$('#aiBoard'),endBtn:$('#endTurnBtn'),muteBtn:$('#muteBtn'),aAva:$('#aiAvatar'),drawCount:$('#drawCount'),discardCount:$('#discardCount'),barPHP:$('#barPlayerHP'),barAHP:$('#barAiHP'),barMana:$('#barMana'),wrap:$('#gameWrap'),start:$('#start'),openEncy:$('#openEncy'),ency:$('#ency'),encyGrid:$('#encyGrid'),encyFilters:$('#encyFilters'),closeEncy:$('#closeEncy'),startGame:$('#startGame'),endOverlay:$('#endOverlay'),endMsg:$('#endMsg'),endSub:$('#endSub'),playAgainBtn:$('#playAgainBtn'),rematchBtn:$('#rematchBtn'),menuBtn:$('#menuBtn'),openMenuBtn:$('#openMenuBtn'),gameMenu:$('#gameMenu'),closeMenuBtn:$('#closeMenuBtn'),resignBtn:$('#resignBtn'),restartBtn:$('#restartBtn'),mainMenuBtn:$('#mainMenuBtn'),turnIndicator:$('#turnIndicator'),emojiBar:$('#emojiBar'),playerEmoji:$('#playerEmoji'),opponentEmoji:$('#opponentEmoji'),deckBuilder:$('#deckBuilder'),saveDeck:$('#saveDeck'),midMana:$('#midMana'),playerCommander:$('#playerCommander'),aiCommander:$('#aiCommander')};
 els.startGame.disabled=true;
 
 function updateCardSize(){
@@ -410,7 +410,7 @@ function renderAll(){
   }
   els.drawCount.textContent=G.playerDeck.length;
   els.discardCount.textContent=G.playerDiscard.length;
-  updateMeters();updateOpponentLabel();renderHand();renderBoard();renderTotems()
+  updateMeters();updateOpponentLabel();renderHand();renderBoard();renderCommanders();renderTotems()
 }
 function renderHand(){
   els.pHand.innerHTML='';
@@ -1189,6 +1189,22 @@ function renderTotems(){
     slot.className='totem-slot';
     if(G.totems[i]){ const t=G.totems[i]; slot.textContent=totemIcon(t); try{ slot.setAttribute('data-tip', `${t.name||'Totem'} — ${describeTotem(t)}`);}catch(_){ } }
     bar.appendChild(slot);
+  }
+}
+function renderCommanders(){
+  if(els.playerCommander){
+    els.playerCommander.innerHTML='';
+    if(G.playerCommander){
+      const d=cardNode(G.playerCommander,'player');
+      els.playerCommander.appendChild(d);
+    }
+  }
+  if(els.aiCommander){
+    els.aiCommander.innerHTML='';
+    if(G.aiCommander){
+      const d=cardNode(G.aiCommander,'ai');
+      els.aiCommander.appendChild(d);
+    }
   }
 }
 document.addEventListener('pointerdown',()=>{tryStartMenuMusicImmediate()},{once:true});


### PR DESCRIPTION
## Summary
- Place commander containers next to player and AI decks
- Style commander areas to match card dimensions
- Render commander cards into the new containers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b7300d85dc832b84781856618a4681