### PR TITLE
feat: add commander items and effects

### DIFF
--- a/js/game/items.js
+++ b/js/game/items.js
@@ -1,0 +1,52 @@
+export const ITEMS = {
+  weapons: [
+    {
+      id: 'battle_axe',
+      name: 'Machado Rúnico',
+      atk: 2,
+      classes: ['dps', 'tank']
+    },
+    {
+      id: 'healing_staff',
+      name: 'Cajado Sagrado',
+      atk: 1,
+      classes: ['support', 'control']
+    }
+  ],
+  armors: [
+    {
+      id: 'iron_shield',
+      name: 'Escudo de Ferro',
+      hp: 2,
+      classes: ['tank', 'support']
+    },
+    {
+      id: 'wolf_pelt',
+      name: 'Pele de Lobo',
+      hp: 1,
+      classes: ['dps', 'control']
+    }
+  ],
+  spells: [
+    {
+      id: 'odin_blessing',
+      name: 'Bênção de Odin',
+      buff: { atk: 1 },
+      classes: ['support', 'dps']
+    },
+    {
+      id: 'spirit_link',
+      name: 'Vínculo Espiritual',
+      buff: { hp: 1 },
+      classes: ['support', 'control']
+    }
+  ]
+};
+
+export function findItem(id) {
+  for (const group of Object.values(ITEMS)) {
+    const found = group.find((i) => i.id === id);
+    if (found) return found;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- add item list with weapons, armor and spells
- allow commanders to equip items and apply their buffs
- factor commander armor into face damage calculations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b730125754832bb37cc4217833678f